### PR TITLE
Fix time.Parse layout.

### DIFF
--- a/vcs/git_cmd.go
+++ b/vcs/git_cmd.go
@@ -165,7 +165,7 @@ func (fs *gitFSCmd) Stat(path string) (os.FileInfo, error) {
 		return nil, err
 	}
 
-	mtime, err := time.Parse("Mon Jan _2 15:04:05 2006 +0000",
+	mtime, err := time.Parse("Mon Jan _2 15:04:05 2006 -0700",
 		strings.Trim(string(out), "\n"))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
[time.Parse](http://godoc.org/time#Parse) expects the layout to have `-0700` and fails when `+0000` is used instead.

E.g.,

``` Go
_, err := time.Parse("Mon Jan _2 15:04:05 2006 +0000", "Sun Apr 27 21:26:58 2014 -0500")
if err != nil {
    fmt.Println(err)
}

// Output:
// parsing time "Sun Apr 27 21:26:58 2014 -0700" as "Mon Jan _2 15:04:05 2006 +0000": cannot parse "-0500" as " +0000"
```

``` Go
_, err := time.Parse("Mon Jan _2 15:04:05 2006 -0700", "Sun Apr 27 21:26:58 2014 -0500")
if err == nil {
    fmt.Println("ok")
}

// Output:
// ok
```
