### PR TITLE
Check SSH host keys

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -74,3 +74,210 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+---------------------
+
+Uses code from fleet (https://github.com/coreos/fleet):
+
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/cmd/go-vcs/go-vcs.go
+++ b/cmd/go-vcs/go-vcs.go
@@ -52,7 +52,15 @@ func main() {
 
 		log.Printf("Cloning %s to %s...", cloneURL, dir)
 
-		repo, err := vcs.Clone("git", cloneURL.String(), dir, vcs.CloneOpt{})
+		opt := vcs.CloneOpt{}
+		if *sshKeyFile != "" {
+			key, err := ioutil.ReadFile(*sshKeyFile)
+			if err != nil {
+				log.Fatal(err)
+			}
+			opt.RemoteOpts.SSH = &vcs.SSHConfig{PrivateKey: key}
+		}
+		repo, err := vcs.Clone("git", cloneURL.String(), dir, opt)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/vcs/ssh/hostkey.go
+++ b/vcs/ssh/hostkey.go
@@ -1,0 +1,233 @@
+/*
+   Copyright 2014 CoreOS, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package ssh
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strings"
+
+	"crypto/hmac"
+	"crypto/sha1"
+
+	"code.google.com/p/go.crypto/ssh"
+)
+
+const (
+	sshHashDelim  = "|" // hostfile.h
+	sshHashPrefix = "|1|"
+)
+
+// A KnownHost is a hostname and a known host key associated with that
+// hostname. The hostname can be either unhashed or hashed.
+type KnownHost struct {
+	Hostnames []string // unhashed hostnames (represented as comma-separated names in the original file)
+
+	Salt, Hash []byte // hashed hostname
+
+	Key ssh.PublicKey
+}
+
+// Match returns whether hostname matches this known host entry's
+// unhashed hostnames (separated by comma) or the hashed hostname.
+func (h *KnownHost) Match(hostname string) bool {
+	// TODO(sqs): lowercase before comparing? will that break hashed hostname lookups?
+
+	for _, hn := range h.Hostnames {
+		if hn == hostname {
+			return true
+		}
+	}
+
+	if h.Salt != nil && h.Hash != nil {
+		mac := hmac.New(sha1.New, h.Salt)
+		mac.Write([]byte(hostname))
+		hash := mac.Sum(nil)
+		if bytes.Equal(h.Hash, hash) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// KnownHosts is a collection of known hosts and their host
+// keys. Because hostname key may be hashed, use Lookup to get the
+// host keys for a hostname instead of simply iterating over them and
+// checking the Hostname field.
+type KnownHosts []*KnownHost
+
+// Lookup looks up hostname (which must be an unhashed hostname) in
+// the known hosts collection. It returns host keys that match the
+// unhashed hostname and the hashed variant of it. If any host keys
+// are found, found is true; otherwise it is false.
+func (khs KnownHosts) Lookup(hostname string) (hostKeys []ssh.PublicKey, found bool) {
+	for _, h := range khs {
+		if h.Match(hostname) {
+			hostKeys = append(hostKeys, h.Key)
+			found = true
+		}
+	}
+	return hostKeys, found
+}
+
+// ReadStandardKnownHostsFiles reads and parses the known_hosts files
+// at /etc/ssh/ssh_known_hosts and ~/.ssh/known_hosts.
+func ReadStandardKnownHostsFiles() (KnownHosts, error) {
+	// System known_hosts
+	kh, err := ReadKnownHostsFile("/etc/ssh/known_hosts")
+	if err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+
+	// User known_hosts
+	u, err := user.Current()
+	if err != nil {
+		return nil, err
+	}
+	if u.HomeDir != "" {
+		kh1, err := ReadKnownHostsFile(filepath.Join(u.HomeDir, ".ssh/known_hosts"))
+		if err != nil && !os.IsNotExist(err) {
+			return nil, err
+		}
+		kh = append(kh, kh1...)
+	}
+
+	return kh, nil
+}
+
+// ReadKnownHostsFile reads the known_hosts file at path.
+func ReadKnownHostsFile(path string) (KnownHosts, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	// Check perms. TODO(sqs): we should really call Lstat on the path and not Stat here, and then avoid the TOCTTOU bug...
+	fi, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if fi.Mode().Perm()&0077 > 0 {
+		return nil, fmt.Errorf("known_hosts file %s must not be accessible to others")
+	}
+
+	return ParseKnownHosts(f)
+}
+
+// ParseKnownHosts parses an SSH known_hosts file.
+func ParseKnownHosts(r io.Reader) (KnownHosts, error) {
+	var khs KnownHosts
+	s := bufio.NewScanner(r)
+	n := 0
+	for s.Scan() {
+		n++
+		line := s.Bytes()
+
+		kh, err := parseKnownHostsLine(line)
+		if err != nil {
+			return nil, fmt.Errorf("parsing known_hosts: %s (line %d)", err, n)
+		}
+		if kh == nil {
+			// empty line
+			continue
+		}
+
+		khs = append(khs, kh)
+	}
+	if err := s.Err(); err != nil {
+		return nil, err
+	}
+	return khs, nil
+}
+
+// parseKnownHostsLine parses a line from a known hosts file.  It
+// returns a string containing the hosts section of the line, an
+// ssh.PublicKey parsed from the line, and any error encountered
+// during the parsing.
+func parseKnownHostsLine(line []byte) (*KnownHost, error) {
+	// Skip any leading whitespace.
+	line = bytes.TrimLeft(line, "\t ")
+
+	// Skip comments and empty lines.
+	if bytes.HasPrefix(line, []byte("#")) || len(line) == 0 {
+		return nil, nil
+	}
+
+	// Skip markers.
+	if bytes.HasPrefix(line, []byte("@")) {
+		return nil, errors.New("marker functionality not implemented")
+	}
+
+	// Find the end of the hostname(s) portion.
+	end := bytes.IndexAny(line, "\t ")
+	if end <= 0 {
+		return nil, errors.New("bad format (insufficient fields)")
+	}
+	hosts := line[:end]
+	keyBytes := line[end+1:]
+
+	kh := &KnownHost{}
+
+	// Check for hashed hostnames.
+	if bytes.HasPrefix(hosts, []byte(sshHashPrefix)) {
+		hosts = bytes.TrimPrefix(hosts, []byte(sshHashPrefix))
+		// Hashed hostname format:
+		//  <host>     = the hostname/address to be hashed
+		//  <salt_b64> = base64(random 64 bits)
+		//  <hash_b64> = base64(SHA1(<salt> <host>))
+		//  <salt/hash pair> = '|1|' salt_b64 '|' hash_b64
+		delim := bytes.Index(hosts, []byte(sshHashDelim))
+		if delim <= 0 || delim >= len(hosts) {
+			return nil, errors.New("bad hashed hostname format")
+		}
+		salt64 := hosts[:delim]
+		hash64 := hosts[delim+1:]
+		b64 := base64.StdEncoding
+		kh.Salt = make([]byte, b64.DecodedLen(len(salt64)))
+		kh.Hash = make([]byte, b64.DecodedLen(len(hash64)))
+		if n, err := b64.Decode(kh.Salt, salt64); err != nil {
+			return nil, err
+		} else {
+			kh.Salt = kh.Salt[:n]
+		}
+		if n, err := b64.Decode(kh.Hash, hash64); err != nil {
+			return nil, err
+		} else {
+			kh.Hash = kh.Hash[:n]
+		}
+	} else {
+		kh.Hostnames = strings.Split(string(hosts), ",")
+	}
+
+	// Finally, actually try to extract the key.
+	key, _, _, _, err := ssh.ParseAuthorizedKey(keyBytes)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing key: %v", err)
+	}
+	kh.Key = key
+
+	return kh, nil
+}

--- a/vcs/ssh/hostkey_test.go
+++ b/vcs/ssh/hostkey_test.go
@@ -1,0 +1,42 @@
+package ssh
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseKnownHosts_ok(t *testing.T) {
+	data := `
+xenon.stanford.edu,171.64.66.201 ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAsWfJKexGQfH549CzZHbmaGRJ1307nkCADIJqmnZQpMSWiE1yGxOWevjYMv4nxqefQko8W3ixNTUs0dzFvmxImAqNId6F8RBW3jt7rj6o1+L9VNCx2UtWUtr0CXifAUnef2iPoT3vS50IkArHp71M8fDruH5wbPcbnP76odGfODWJU2qcNHIMbLoUuxULUHSzCzM+kOVCC9nl7P1OJUbsvuw5mjBJbFRbQW1Zctny1lyRlftDGUjYYBR5G18qtn6w0+w9OhCoSAFd1bQq982kfgVIRQokhLC7Eq24cQTKT85zN/m8I9lptkxWGsHcTV9nMG+LKv2pbE3JOPqwR/556Q==
+|1|Lr7o99feGO4XWwfc09dxyiY/nMo=|TRs4gnNyZS1i1QbBW5XvGbjr1R8= ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==
+ 
+|1|k4TmSR1fbu8pZ9cubTOMXcQguUc=|SsAqIoaKcq/KzLN7o2pVdToZPzs= ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==
+`
+	kh, err := ParseKnownHosts(strings.NewReader(data))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := kh.Lookup("xenon.stanford.edu"); !ok {
+		t.Error("got no xenon.stanford.edu host key, want 1")
+	}
+	if _, ok := kh.Lookup("171.64.66.201"); !ok {
+		t.Error("got no xenon.stanford.edu host key, want 1")
+	}
+	if _, ok := kh.Lookup("github.com"); !ok {
+		t.Error("got no github.com host key, want 1")
+	}
+	if _, ok := kh.Lookup("doesntexist.com"); ok {
+		t.Error("got doesntexist.com host key, want none")
+	}
+}
+
+func TestParseKnownHosts_invalidFormat(t *testing.T) {
+	data := `
+bad format
+`
+
+	if _, err := ParseKnownHosts(strings.NewReader(data)); err == nil {
+		t.Fatal("got err == nil, want non-nil err")
+	}
+}


### PR DESCRIPTION
Adds support for reading, parsing, and looking up SSH host keys from
known_host files. Also makes the libgit2 implementation check the SSH
host's host key against the standard known_hosts files when using an
SSH remote.
