### PR TITLE
Fully support symlinks and submodules

### DIFF
--- a/vcs/file_info.go
+++ b/vcs/file_info.go
@@ -1,0 +1,23 @@
+package vcs
+
+// ModeSubmodule is an os.FileMode mask indicating that the file is a
+// VCS submodule (e.g., a git submodule).
+const ModeSubmodule = 0160000
+
+// SubmoduleInfo holds information about a VCS submodule and is
+// returned in the FileInfo's Sys field by Stat/Lstat/ReadDir calls.
+type SubmoduleInfo struct {
+	// URL is the submodule repository origin URL.
+	URL string
+
+	// CommitID is the pinned commit ID of the submodule (in the
+	// submodule repository's commit ID space).
+	CommitID
+}
+
+// SymlinkInfo holds information about a symlink and is returned in
+// the FileInfo's Sys field by Stat/Lstat/ReadDir calls.
+type SymlinkInfo struct {
+	// Dest is the path that the symlink points to.
+	Dest string
+}

--- a/vcs/util/fileinfo.go
+++ b/vcs/util/fileinfo.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"os"
+	"sort"
 	"time"
 )
 
@@ -20,3 +21,14 @@ func (fi *FileInfo) Mode() os.FileMode  { return fi.Mode_ }
 func (fi *FileInfo) ModTime() time.Time { return fi.ModTime_ }
 func (fi *FileInfo) IsDir() bool        { return fi.Mode().IsDir() }
 func (fi *FileInfo) Sys() interface{}   { return fi.Sys_ }
+
+// SortFileInfosByName sorts fis by name, alphabetically.
+func SortFileInfosByName(fis []os.FileInfo) {
+	sort.Sort(fileInfosByName(fis))
+}
+
+type fileInfosByName []os.FileInfo
+
+func (v fileInfosByName) Len() int           { return len(v) }
+func (v fileInfosByName) Less(i, j int) bool { return v[i].Name() < v[j].Name() }
+func (v fileInfosByName) Swap(i, j int)      { v[i], v[j] = v[j], v[i] }


### PR DESCRIPTION
Lstat, Stat, and ReadDir now properly handle symlinks and (git) submodules. In addition:
- the Sys() method of the os.FileInfo for a symlink returns a SymlinkInfo that contains the symlink's destination
- the Sys() method of the os.FileInfo for a git submodule returns a SubmoduleInfo that contains the submodule's URL and commit ID
