### PR TITLE
Cross-repo merge-base

### DIFF
--- a/vcs/merge.go
+++ b/vcs/merge.go
@@ -7,3 +7,16 @@ type Merger interface {
 	// commits (aka greatest common ancestor commit for hg).
 	MergeBase(CommitID, CommitID) (CommitID, error)
 }
+
+// A CrossRepoMerger is a repository that can perform merge-related
+// actions across separate repositories.
+type CrossRepoMerger interface {
+	// CrossRepoMergeBase returns the merge base commit for the
+	// specified commits (aka greatest common ancestor commit for hg).
+	//
+	// The commit specified by `b` must exist in repoB but does not
+	// need to exist in the repository that CrossRepoMergeBase is
+	// called on. Likewise, the commit specified by `a` need not exist
+	// in repoB.
+	CrossRepoMergeBase(a CommitID, repoB Repository, b CommitID) (CommitID, error)
+}

--- a/vcs/merge_test.go
+++ b/vcs/merge_test.go
@@ -78,3 +78,87 @@ func TestMerger_MergeBase(t *testing.T) {
 		}
 	}
 }
+
+func TestMerger_CrossRepoMergeBase(t *testing.T) {
+	t.Parallel()
+
+	// TODO(sqs): implement for hg
+	// TODO(sqs): make a more complex test case
+
+	cmdsA := []string{
+		"echo line1 > f",
+		"git add f",
+		"GIT_COMMITTER_NAME=a GIT_COMMITTER_EMAIL=a@a.com GIT_COMMITTER_DATE=2006-01-02T15:04:05Z git commit -m foo --author='a <a@a.com>' --date 2006-01-02T15:04:05Z",
+		"git tag testbase",
+	}
+	cmdsB := []string{
+		"echo line1 > f",
+		"git add f",
+		"GIT_COMMITTER_NAME=a GIT_COMMITTER_EMAIL=a@a.com GIT_COMMITTER_DATE=2006-01-02T15:04:05Z git commit -m foo --author='a <a@a.com>' --date 2006-01-02T15:04:05Z",
+		"git tag testbase",
+		"git checkout -b b2",
+		"echo line2 >> f",
+		"git add f",
+		"GIT_COMMITTER_NAME=a GIT_COMMITTER_EMAIL=a@a.com GIT_COMMITTER_DATE=2006-01-02T15:04:05Z git commit -m foo --author='a <a@a.com>' --date 2006-01-02T15:04:05Z",
+		"git checkout master",
+		"echo line3 > h",
+		"git add h",
+		"GIT_COMMITTER_NAME=a GIT_COMMITTER_EMAIL=a@a.com GIT_COMMITTER_DATE=2006-01-02T15:04:05Z git commit -m qux --author='a <a@a.com>' --date 2006-01-02T15:04:05Z",
+	}
+	tests := map[string]struct {
+		repoA interface {
+			vcs.CrossRepoMerger
+			ResolveRevision(spec string) (vcs.CommitID, error)
+		}
+		repoB vcs.Repository
+		a, b  string // can be any revspec; is resolved during the test
+
+		wantMergeBase string // can be any revspec; is resolved during test
+	}{
+		"git libgit2": {
+			repoA: makeGitRepositoryLibGit2(t, cmdsA...),
+			repoB: makeGitRepositoryLibGit2(t, cmdsB...),
+
+			a: "master", b: "b2",
+			wantMergeBase: "testbase",
+		},
+		"git cmd": {
+			repoA: makeGitRepositoryCmd(t, cmdsA...),
+			repoB: makeGitRepositoryCmd(t, cmdsB...),
+
+			a: "master", b: "b2",
+			wantMergeBase: "testbase",
+		},
+	}
+
+	for label, test := range tests {
+		a, err := test.repoA.ResolveRevision(test.a)
+		if err != nil {
+			t.Errorf("%s: ResolveRevision(%q) on a: %s", label, test.a, err)
+			continue
+		}
+
+		b, err := test.repoB.ResolveRevision(test.b)
+		if err != nil {
+			t.Errorf("%s: ResolveRevision(%q) on b: %s", label, test.b, err)
+			continue
+		}
+
+		want, err := test.repoA.ResolveRevision(test.wantMergeBase)
+		if err != nil {
+			t.Errorf("%s: ResolveRevision(%q) on wantMergeBase: %s", label, test.wantMergeBase, err)
+			continue
+		}
+
+		mb, err := test.repoA.CrossRepoMergeBase(a, test.repoB, b)
+		if err != nil {
+			t.Errorf("%s: CrossRepoMergeBase(%s, %s, %s): %s", label, a, test.repoB, b, err)
+			continue
+		}
+
+		if mb != want {
+			t.Errorf("%s: CrossRepoMergeBase(%s, %s, %s): got %q, want %q", label, a, test.repoB, b, mb, want)
+			continue
+		}
+	}
+}

--- a/vcs/testing/mock_repository.go
+++ b/vcs/testing/mock_repository.go
@@ -22,6 +22,9 @@ type MockRepository struct {
 
 	Diff_          func(base, head vcs.CommitID, opt *vcs.DiffOptions) (*vcs.Diff, error)
 	CrossRepoDiff_ func(base vcs.CommitID, headRepo vcs.Repository, head vcs.CommitID, opt *vcs.DiffOptions) (*vcs.Diff, error)
+
+	MergeBase_          func(a, b vcs.CommitID) (vcs.CommitID, error)
+	CrossRepoMergeBase_ func(a vcs.CommitID, repoB vcs.Repository, b vcs.CommitID) (vcs.CommitID, error)
 }
 
 var (
@@ -73,4 +76,12 @@ func (r MockRepository) Diff(base, head vcs.CommitID, opt *vcs.DiffOptions) (*vc
 
 func (r MockRepository) CrossRepoDiff(base vcs.CommitID, headRepo vcs.Repository, head vcs.CommitID, opt *vcs.DiffOptions) (*vcs.Diff, error) {
 	return r.CrossRepoDiff_(base, headRepo, head, opt)
+}
+
+func (r MockRepository) MergeBase(a, b vcs.CommitID) (vcs.CommitID, error) {
+	return r.MergeBase_(a, b)
+}
+
+func (r MockRepository) CrossRepoMergeBase(a vcs.CommitID, repoB vcs.Repository, b vcs.CommitID) (vcs.CommitID, error) {
+	return r.CrossRepoMergeBase_(a, repoB, b)
 }


### PR DESCRIPTION
Like CrossRepoDiff, the CrossRepoMergeBase computes the merge-base
(aka common ancestor) between two commits that can exist in two
different repositories.
