### PR TITLE
Add BranchesOptions for Repository.Branches method, support getting behind/ahead counts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,17 @@ Installing
 go get -u sourcegraph.com/sourcegraph/go-vcs/vcs
 ```
 
+Implementation differences
+==========================
+
+The goal is to have all supported backends at feature parity, but until then, consult this table for implementation differences.
+
+| Feature                                 | `git`                | `gitcmd`           | `hg`                 | `hgcmd`              |
+|-----------------------------------------|----------------------|--------------------|----------------------|----------------------|
+| `vcs.BranchesOptions.BehindAheadBranch` | :white_large_square: | :white_check_mark: | :white_large_square: | :white_large_square: |
+
+Contributions that fill in the gaps are welcome!
+
 
 Running tests
 =============
@@ -47,3 +58,5 @@ Contributors
 ============
 
 * Quinn Slack <sqs@sourcegraph.com>
+
+See all contributors [here](https://github.com/sourcegraph/go-vcs/graphs/contributors).

--- a/cmd/go-vcs/go-vcs.go
+++ b/cmd/go-vcs/go-vcs.go
@@ -320,7 +320,7 @@ func main() {
 			log.Fatalln("no supported vcs found in cwd")
 		}
 
-		repo, err := vcs.Open(r.Type().VcsType(), ".")
+		repo, err := vcs.Open(r.Type().VcsType(), r.RootPath())
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/go-vcs/go-vcs.go
+++ b/cmd/go-vcs/go-vcs.go
@@ -329,12 +329,12 @@ func main() {
 		if len(args) == 1 {
 			opt.BehindAheadBranch = args[0]
 		}
-		branches, total, err := repo.Branches(opt)
+		branches, err := repo.Branches(opt)
 		if err != nil {
 			log.Fatal(err)
 		}
 
-		fmt.Printf("# Branches (%d total):\n", total)
+		fmt.Printf("# Branches (%d total):\n", len(branches))
 		for _, b := range branches {
 			switch {
 			case b.Counts == nil:

--- a/vcs/git/repo.go
+++ b/vcs/git/repo.go
@@ -104,13 +104,13 @@ func (r *Repository) ResolveTag(name string) (vcs.CommitID, error) {
 	return "", vcs.ErrTagNotFound
 }
 
-func (r *Repository) Branches(_ vcs.BranchesOptions) (branches []*vcs.Branch, total uint, err error) {
+func (r *Repository) Branches(_ vcs.BranchesOptions) ([]*vcs.Branch, error) {
 	r.editLock.RLock()
 	defer r.editLock.RUnlock()
 
 	refs, err := r.u.NewReferenceIterator()
 	if err != nil {
-		return nil, 0, err
+		return nil, err
 	}
 
 	var bs []*vcs.Branch
@@ -120,7 +120,7 @@ func (r *Repository) Branches(_ vcs.BranchesOptions) (branches []*vcs.Branch, to
 			break
 		}
 		if err != nil {
-			return nil, 0, err
+			return nil, err
 		}
 		if ref.IsBranch() {
 			bs = append(bs, &vcs.Branch{Name: ref.Shorthand(), Head: vcs.CommitID(ref.Target().String())})
@@ -128,7 +128,7 @@ func (r *Repository) Branches(_ vcs.BranchesOptions) (branches []*vcs.Branch, to
 	}
 
 	sort.Sort(vcs.Branches(bs))
-	return bs, uint(len(bs)), nil
+	return bs, nil
 }
 
 func (r *Repository) Tags() ([]*vcs.Tag, error) {

--- a/vcs/git/repo.go
+++ b/vcs/git/repo.go
@@ -104,13 +104,13 @@ func (r *Repository) ResolveTag(name string) (vcs.CommitID, error) {
 	return "", vcs.ErrTagNotFound
 }
 
-func (r *Repository) Branches() ([]*vcs.Branch, error) {
+func (r *Repository) Branches(_ vcs.BranchesOptions) (branches []*vcs.Branch, total uint, err error) {
 	r.editLock.RLock()
 	defer r.editLock.RUnlock()
 
 	refs, err := r.u.NewReferenceIterator()
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
 	var bs []*vcs.Branch
@@ -120,7 +120,7 @@ func (r *Repository) Branches() ([]*vcs.Branch, error) {
 			break
 		}
 		if err != nil {
-			return nil, err
+			return nil, 0, err
 		}
 		if ref.IsBranch() {
 			bs = append(bs, &vcs.Branch{Name: ref.Shorthand(), Head: vcs.CommitID(ref.Target().String())})
@@ -128,7 +128,7 @@ func (r *Repository) Branches() ([]*vcs.Branch, error) {
 	}
 
 	sort.Sort(vcs.Branches(bs))
-	return bs, nil
+	return bs, uint(len(bs)), nil
 }
 
 func (r *Repository) Tags() ([]*vcs.Tag, error) {

--- a/vcs/gitcmd/repo.go
+++ b/vcs/gitcmd/repo.go
@@ -152,7 +152,14 @@ func (r *Repository) ResolveTag(name string) (vcs.CommitID, error) {
 
 // branchCounts returns the behind/ahead commit counts information for branch, against base branch.
 func (r *Repository) branchCounts(branch, base string) (behind, ahead int, err error) {
-	cmd := exec.Command("git", "rev-list", "--count", "--left-right", base+"..."+branch)
+	if err := checkSpecArgSafety(branch); err != nil {
+		return 0, 0, err
+	}
+	if err := checkSpecArgSafety(base); err != nil {
+		return 0, 0, err
+	}
+
+	cmd := exec.Command("git", "rev-list", "--count", "--left-right", fmt.Sprintf("refs/heads/%s...refs/heads/%s", base, branch))
 	cmd.Dir = r.Dir
 	out, err := cmd.Output()
 	if err != nil {

--- a/vcs/gitcmd/repo.go
+++ b/vcs/gitcmd/repo.go
@@ -177,16 +177,16 @@ func (r *Repository) branchCounts(branch, base string) (behind, ahead uint, err 
 	return uint(b), uint(a), nil
 }
 
-func (r *Repository) Branches(opt vcs.BranchesOptions) (branches []*vcs.Branch, total uint, err error) {
+func (r *Repository) Branches(opt vcs.BranchesOptions) ([]*vcs.Branch, error) {
 	r.editLock.RLock()
 	defer r.editLock.RUnlock()
 
 	refs, err := r.showRef("--heads")
 	if err != nil {
-		return nil, 0, err
+		return nil, err
 	}
 
-	branches = make([]*vcs.Branch, len(refs))
+	branches := make([]*vcs.Branch, len(refs))
 	for i, ref := range refs {
 		branches[i] = &vcs.Branch{
 			Name: strings.TrimPrefix(ref[1], "refs/heads/"),
@@ -199,13 +199,13 @@ func (r *Repository) Branches(opt vcs.BranchesOptions) (branches []*vcs.Branch, 
 		for i, branch := range branches {
 			behind, ahead, err := r.branchCounts(branch.Name, opt.BehindAheadBranch)
 			if err != nil {
-				return nil, 0, err
+				return nil, err
 			}
 			branches[i].Counts = &vcs.BehindAhead{Behind: behind, Ahead: ahead}
 		}
 	}
 
-	return branches, uint(len(branches)), nil
+	return branches, nil
 }
 
 func (r *Repository) Tags() ([]*vcs.Tag, error) {

--- a/vcs/gitcmd/repo.go
+++ b/vcs/gitcmd/repo.go
@@ -151,7 +151,7 @@ func (r *Repository) ResolveTag(name string) (vcs.CommitID, error) {
 }
 
 // branchCounts returns the behind/ahead commit counts information for branch, against base branch.
-func (r *Repository) branchCounts(branch, base string) (behind, ahead int, err error) {
+func (r *Repository) branchCounts(branch, base string) (behind, ahead uint, err error) {
 	if err := checkSpecArgSafety(branch); err != nil {
 		return 0, 0, err
 	}
@@ -166,15 +166,15 @@ func (r *Repository) branchCounts(branch, base string) (behind, ahead int, err e
 		return 0, 0, err
 	}
 	behindAhead := strings.Split(strings.TrimSuffix(string(out), "\n"), "\t")
-	behind, err = strconv.Atoi(behindAhead[0])
+	b, err := strconv.ParseUint(behindAhead[0], 10, 0)
 	if err != nil {
 		return 0, 0, err
 	}
-	ahead, err = strconv.Atoi(behindAhead[1])
+	a, err := strconv.ParseUint(behindAhead[1], 10, 0)
 	if err != nil {
 		return 0, 0, err
 	}
-	return behind, ahead, nil
+	return uint(b), uint(a), nil
 }
 
 func (r *Repository) Branches(opt vcs.BranchesOptions) (branches []*vcs.Branch, total uint, err error) {

--- a/vcs/hg/repo.go
+++ b/vcs/hg/repo.go
@@ -102,7 +102,7 @@ func (r *Repository) ResolveBranch(name string) (vcs.CommitID, error) {
 	return "", vcs.ErrBranchNotFound
 }
 
-func (r *Repository) Branches() ([]*vcs.Branch, error) {
+func (r *Repository) Branches(_ vcs.BranchesOptions) (branches []*vcs.Branch, total uint, err error) {
 	bs := make([]*vcs.Branch, len(r.branchHeads.IdByName))
 	i := 0
 	for name, id := range r.branchHeads.IdByName {
@@ -110,7 +110,7 @@ func (r *Repository) Branches() ([]*vcs.Branch, error) {
 		i++
 	}
 	sort.Sort(vcs.Branches(bs))
-	return bs, nil
+	return bs, uint(len(bs)), nil
 }
 
 func (r *Repository) Tags() ([]*vcs.Tag, error) {

--- a/vcs/hg/repo.go
+++ b/vcs/hg/repo.go
@@ -102,7 +102,7 @@ func (r *Repository) ResolveBranch(name string) (vcs.CommitID, error) {
 	return "", vcs.ErrBranchNotFound
 }
 
-func (r *Repository) Branches(_ vcs.BranchesOptions) (branches []*vcs.Branch, total uint, err error) {
+func (r *Repository) Branches(_ vcs.BranchesOptions) ([]*vcs.Branch, error) {
 	bs := make([]*vcs.Branch, len(r.branchHeads.IdByName))
 	i := 0
 	for name, id := range r.branchHeads.IdByName {
@@ -110,7 +110,7 @@ func (r *Repository) Branches(_ vcs.BranchesOptions) (branches []*vcs.Branch, to
 		i++
 	}
 	sort.Sort(vcs.Branches(bs))
-	return bs, uint(len(bs)), nil
+	return bs, nil
 }
 
 func (r *Repository) Tags() ([]*vcs.Tag, error) {

--- a/vcs/hgcmd/repo.go
+++ b/vcs/hgcmd/repo.go
@@ -95,20 +95,20 @@ func (r *Repository) ResolveBranch(name string) (vcs.CommitID, error) {
 	return commitID, nil
 }
 
-func (r *Repository) Branches(_ vcs.BranchesOptions) (branches []*vcs.Branch, total uint, err error) {
+func (r *Repository) Branches(_ vcs.BranchesOptions) ([]*vcs.Branch, error) {
 	refs, err := r.execAndParseCols("branches")
 	if err != nil {
-		return nil, 0, err
+		return nil, err
 	}
 
-	branches = make([]*vcs.Branch, len(refs))
+	branches := make([]*vcs.Branch, len(refs))
 	for i, ref := range refs {
 		branches[i] = &vcs.Branch{
 			Name: ref[1],
 			Head: vcs.CommitID(ref[0]),
 		}
 	}
-	return branches, uint(len(branches)), nil
+	return branches, nil
 }
 
 func (r *Repository) Tags() ([]*vcs.Tag, error) {

--- a/vcs/hgcmd/repo.go
+++ b/vcs/hgcmd/repo.go
@@ -95,20 +95,20 @@ func (r *Repository) ResolveBranch(name string) (vcs.CommitID, error) {
 	return commitID, nil
 }
 
-func (r *Repository) Branches() ([]*vcs.Branch, error) {
+func (r *Repository) Branches(_ vcs.BranchesOptions) (branches []*vcs.Branch, total uint, err error) {
 	refs, err := r.execAndParseCols("branches")
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
-	branches := make([]*vcs.Branch, len(refs))
+	branches = make([]*vcs.Branch, len(refs))
 	for i, ref := range refs {
 		branches[i] = &vcs.Branch{
 			Name: ref[1],
 			Head: vcs.CommitID(ref[0]),
 		}
 	}
-	return branches, nil
+	return branches, uint(len(branches)), nil
 }
 
 func (r *Repository) Tags() ([]*vcs.Tag, error) {

--- a/vcs/repository.go
+++ b/vcs/repository.go
@@ -161,8 +161,8 @@ type Branch struct {
 
 // BehindAhead is a set of behind/ahead counts.
 type BehindAhead struct {
-	Behind int
-	Ahead  int
+	Behind uint
+	Ahead  uint
 }
 
 type Branches []*Branch

--- a/vcs/repository.go
+++ b/vcs/repository.go
@@ -144,7 +144,11 @@ type Diff struct {
 // BranchesOptions specifies options for the list of branches returned by
 // (Repository).Branches.
 type BranchesOptions struct {
-	BehindAheadBranch string `json:",omitempty" url:",omitempty"` // Or "" to disable fetching behind/ahead counts.
+	// BehindAheadBranch specifies a branch name. If set to something other than blank string,
+	// then each returned branch will include a behind/ahead commit counts information
+	// against the specified base branch. If left blank, then branches
+	// will not include that information and their Counts will be nil.
+	BehindAheadBranch string `json:",omitempty" url:",omitempty"`
 }
 
 // A Branch is a VCS branch.

--- a/vcs/repository.go
+++ b/vcs/repository.go
@@ -27,8 +27,9 @@ type Repository interface {
 	// ErrBranchNotFound if no such branch exists.
 	ResolveBranch(name string) (CommitID, error)
 
-	// Branches returns a list of all branches in the repository.
-	Branches() ([]*Branch, error)
+	// Branches returns a list of all branches in the repository, as well as
+	// the total number of branches.
+	Branches(BranchesOptions) (branches []*Branch, total uint, err error)
 
 	// Tags returns a list of all tags in the repository.
 	Tags() ([]*Tag, error)
@@ -140,10 +141,24 @@ type Diff struct {
 	Raw string // the raw diff output
 }
 
+// BranchesOptions specifies options for the list of branches returned by
+// (Repository).Branches.
+type BranchesOptions struct {
+	BehindAheadBranch string `json:",omitempty" url:",omitempty"` // Or "" to disable fetching behind/ahead counts.
+}
+
 // A Branch is a VCS branch.
 type Branch struct {
 	Name string
 	Head CommitID
+
+	Counts *BehindAhead `json:",omitempty"` // Counts optionally contains the commit counts relative to specified branch.
+}
+
+// BehindAhead is a set of behind/ahead counts.
+type BehindAhead struct {
+	Behind int
+	Ahead  int
 }
 
 type Branches []*Branch

--- a/vcs/repository.go
+++ b/vcs/repository.go
@@ -27,9 +27,8 @@ type Repository interface {
 	// ErrBranchNotFound if no such branch exists.
 	ResolveBranch(name string) (CommitID, error)
 
-	// Branches returns a list of all branches in the repository, as well as
-	// the total number of branches.
-	Branches(BranchesOptions) (branches []*Branch, total uint, err error)
+	// Branches returns a list of all branches in the repository.
+	Branches(BranchesOptions) ([]*Branch, error)
 
 	// Tags returns a list of all tags in the repository.
 	Tags() ([]*Tag, error)

--- a/vcs/repository_test.go
+++ b/vcs/repository_test.go
@@ -391,7 +391,7 @@ func TestRepository_Branches(t *testing.T) {
 	}
 	tests := map[string]struct {
 		repo interface {
-			Branches(vcs.BranchesOptions) ([]*vcs.Branch, uint, error)
+			Branches(vcs.BranchesOptions) ([]*vcs.Branch, error)
 		}
 		wantBranches []*vcs.Branch
 	}{
@@ -414,7 +414,7 @@ func TestRepository_Branches(t *testing.T) {
 	}
 
 	for label, test := range tests {
-		branches, _, err := test.repo.Branches(vcs.BranchesOptions{})
+		branches, err := test.repo.Branches(vcs.BranchesOptions{})
 		if err != nil {
 			t.Errorf("%s: Branches: %s", label, err)
 			continue

--- a/vcs/repository_test.go
+++ b/vcs/repository_test.go
@@ -391,7 +391,7 @@ func TestRepository_Branches(t *testing.T) {
 	}
 	tests := map[string]struct {
 		repo interface {
-			Branches() ([]*vcs.Branch, error)
+			Branches(vcs.BranchesOptions) ([]*vcs.Branch, uint, error)
 		}
 		wantBranches []*vcs.Branch
 	}{
@@ -414,7 +414,7 @@ func TestRepository_Branches(t *testing.T) {
 	}
 
 	for label, test := range tests {
-		branches, err := test.repo.Branches()
+		branches, _, err := test.repo.Branches(vcs.BranchesOptions{})
 		if err != nil {
 			t.Errorf("%s: Branches: %s", label, err)
 			continue

--- a/vcs/repository_test.go
+++ b/vcs/repository_test.go
@@ -426,6 +426,53 @@ func TestRepository_Branches(t *testing.T) {
 	}
 }
 
+func TestRepository_BranchesCounts(t *testing.T) {
+	t.Parallel()
+
+	gitCommands := []string{
+		"GIT_COMMITTER_NAME=a GIT_COMMITTER_EMAIL=a@a.com GIT_COMMITTER_DATE=2006-01-02T15:04:05Z git commit --allow-empty -m foo0 --author='a <a@a.com>' --date 2006-01-02T15:04:05Z",
+		"git branch old_work",
+		"GIT_COMMITTER_NAME=a GIT_COMMITTER_EMAIL=a@a.com GIT_COMMITTER_DATE=2006-01-02T15:04:05Z git commit --allow-empty -m foo1 --author='a <a@a.com>' --date 2006-01-02T15:04:05Z",
+		"GIT_COMMITTER_NAME=a GIT_COMMITTER_EMAIL=a@a.com GIT_COMMITTER_DATE=2006-01-02T15:04:05Z git commit --allow-empty -m foo2 --author='a <a@a.com>' --date 2006-01-02T15:04:05Z",
+		"GIT_COMMITTER_NAME=a GIT_COMMITTER_EMAIL=a@a.com GIT_COMMITTER_DATE=2006-01-02T15:04:05Z git commit --allow-empty -m foo3 --author='a <a@a.com>' --date 2006-01-02T15:04:05Z",
+		"GIT_COMMITTER_NAME=a GIT_COMMITTER_EMAIL=a@a.com GIT_COMMITTER_DATE=2006-01-02T15:04:05Z git commit --allow-empty -m foo4 --author='a <a@a.com>' --date 2006-01-02T15:04:05Z",
+		"GIT_COMMITTER_NAME=a GIT_COMMITTER_EMAIL=a@a.com GIT_COMMITTER_DATE=2006-01-02T15:04:05Z git commit --allow-empty -m foo5 --author='a <a@a.com>' --date 2006-01-02T15:04:05Z",
+		"git checkout -b dev",
+		"GIT_COMMITTER_NAME=a GIT_COMMITTER_EMAIL=a@a.com GIT_COMMITTER_DATE=2006-01-02T15:04:05Z git commit --allow-empty -m foo6 --author='a <a@a.com>' --date 2006-01-02T15:04:05Z",
+		"GIT_COMMITTER_NAME=a GIT_COMMITTER_EMAIL=a@a.com GIT_COMMITTER_DATE=2006-01-02T15:04:05Z git commit --allow-empty -m foo7 --author='a <a@a.com>' --date 2006-01-02T15:04:05Z",
+		"GIT_COMMITTER_NAME=a GIT_COMMITTER_EMAIL=a@a.com GIT_COMMITTER_DATE=2006-01-02T15:04:05Z git commit --allow-empty -m foo8 --author='a <a@a.com>' --date 2006-01-02T15:04:05Z",
+		"git checkout old_work",
+		"GIT_COMMITTER_NAME=a GIT_COMMITTER_EMAIL=a@a.com GIT_COMMITTER_DATE=2006-01-02T15:04:05Z git commit --allow-empty -m foo9 --author='a <a@a.com>' --date 2006-01-02T15:04:05Z",
+	}
+	tests := map[string]struct {
+		repo interface {
+			Branches(vcs.BranchesOptions) ([]*vcs.Branch, error)
+		}
+		wantBranches []*vcs.Branch
+	}{
+		"git cmd": {
+			repo: makeGitRepositoryCmd(t, gitCommands...),
+			wantBranches: []*vcs.Branch{
+				{Counts: &vcs.BehindAhead{Behind: 5, Ahead: 1}, Name: "old_work", Head: "26692c614c59ddaef4b57926810aac7d5f0e94f0"},
+				{Counts: &vcs.BehindAhead{Behind: 0, Ahead: 3}, Name: "dev", Head: "6724953367f0cd9a7755bac46ee57f4ab0c1aad8"},
+				{Counts: &vcs.BehindAhead{Behind: 0, Ahead: 0}, Name: "master", Head: "8ea26e077a8fb9aa502c3fe2cfa3ce4e052d1a76"},
+			},
+		},
+	}
+
+	for label, test := range tests {
+		branches, err := test.repo.Branches(vcs.BranchesOptions{BehindAheadBranch: "master"})
+		if err != nil {
+			t.Errorf("%s: Branches: %s", label, err)
+			continue
+		}
+
+		if !reflect.DeepEqual(branches, test.wantBranches) {
+			t.Errorf("%s: got branches == %v, want %v", label, asJSON(branches), asJSON(test.wantBranches))
+		}
+	}
+}
+
 func TestRepository_Tags(t *testing.T) {
 	t.Parallel()
 

--- a/vcs/ssh_test.go
+++ b/vcs/ssh_test.go
@@ -87,7 +87,7 @@ func TestRepository_Clone_ssh(t *testing.T) {
 				t.Errorf("%s: got tags %s, want %s", label, asJSON(tags), asJSON(wantTags))
 			}
 
-			branches, err := r.Branches()
+			branches, _, err := r.Branches(vcs.BranchesOptions{})
 			if err != nil {
 				t.Errorf("%s: Branches: %s", label, err)
 			}
@@ -199,7 +199,7 @@ func TestRepository_UpdateEverything_ssh(t *testing.T) {
 
 			// r should now have the branch b0 we added to the base
 			// repo, since we just updated r.
-			branches, err := r.Branches()
+			branches, _, err := r.Branches(vcs.BranchesOptions{})
 			if err != nil {
 				t.Errorf("%s: Branches: %s", label, err)
 				return

--- a/vcs/ssh_test.go
+++ b/vcs/ssh_test.go
@@ -87,7 +87,7 @@ func TestRepository_Clone_ssh(t *testing.T) {
 				t.Errorf("%s: got tags %s, want %s", label, asJSON(tags), asJSON(wantTags))
 			}
 
-			branches, _, err := r.Branches(vcs.BranchesOptions{})
+			branches, err := r.Branches(vcs.BranchesOptions{})
 			if err != nil {
 				t.Errorf("%s: Branches: %s", label, err)
 			}
@@ -199,7 +199,7 @@ func TestRepository_UpdateEverything_ssh(t *testing.T) {
 
 			// r should now have the branch b0 we added to the base
 			// repo, since we just updated r.
-			branches, _, err := r.Branches(vcs.BranchesOptions{})
+			branches, err := r.Branches(vcs.BranchesOptions{})
 			if err != nil {
 				t.Errorf("%s: Branches: %s", label, err)
 				return

--- a/vcs/testing/mock_repository.go
+++ b/vcs/testing/mock_repository.go
@@ -10,7 +10,7 @@ type MockRepository struct {
 	ResolveTag_      func(name string) (vcs.CommitID, error)
 	ResolveBranch_   func(name string) (vcs.CommitID, error)
 
-	Branches_ func() ([]*vcs.Branch, error)
+	Branches_ func(vcs.BranchesOptions) ([]*vcs.Branch, uint, error)
 	Tags_     func() ([]*vcs.Tag, error)
 
 	GetCommit_ func(vcs.CommitID) (*vcs.Commit, error)
@@ -46,8 +46,8 @@ func (r MockRepository) ResolveBranch(name string) (vcs.CommitID, error) {
 	return r.ResolveBranch_(name)
 }
 
-func (r MockRepository) Branches() ([]*vcs.Branch, error) {
-	return r.Branches_()
+func (r MockRepository) Branches(opt vcs.BranchesOptions) ([]*vcs.Branch, uint, error) {
+	return r.Branches_(opt)
 }
 
 func (r MockRepository) Tags() ([]*vcs.Tag, error) {

--- a/vcs/testing/mock_repository.go
+++ b/vcs/testing/mock_repository.go
@@ -10,7 +10,7 @@ type MockRepository struct {
 	ResolveTag_      func(name string) (vcs.CommitID, error)
 	ResolveBranch_   func(name string) (vcs.CommitID, error)
 
-	Branches_ func(vcs.BranchesOptions) ([]*vcs.Branch, uint, error)
+	Branches_ func(vcs.BranchesOptions) ([]*vcs.Branch, error)
 	Tags_     func() ([]*vcs.Tag, error)
 
 	GetCommit_ func(vcs.CommitID) (*vcs.Commit, error)
@@ -46,7 +46,7 @@ func (r MockRepository) ResolveBranch(name string) (vcs.CommitID, error) {
 	return r.ResolveBranch_(name)
 }
 
-func (r MockRepository) Branches(opt vcs.BranchesOptions) ([]*vcs.Branch, uint, error) {
+func (r MockRepository) Branches(opt vcs.BranchesOptions) ([]*vcs.Branch, error) {
 	return r.Branches_(opt)
 }
 


### PR DESCRIPTION
This is a breaking API change for `Branches` method of `Repository` interface. As any breaking API change, it is not done lightly, but needs to be done in order to support additional features for `Branches` method call. By using an options struct, future enhancements and pagination support will not incur additional API breakage.

- It changes the signature of `Branches` to be more like `Commits`, which accepts an `Options` struct where parameters may be specified that describe details of the `Branches` query.

- ~~It also adds a `total uint` return value, which will always be the total number of branches, even if fewer are returned (due to pagination, for example). Note that there is no pagination support at this time, but since it's likely to be added in the future, it's hopefully better to avoid a second API breakage at that time.~~

- Implement support for `BehindAheadBranch` in `vcs/gitcmd` implementation. If set to a non-empty string, it uses that branch name as the base branch, and gets relative behind/ahead commit counts for each branch returned.

### TODO.

- [ ] Add BehindAheadBranch support to `vcs/git` implementation.
- [x] Add tests.