### PR TITLE
Improve git installation process.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,10 @@ matrix:
     - go: tip
 
 before_install:
-  - mkdir -p $HOME/gopath/src/sourcegraph.com/sourcegraph
-  - mv $TRAVIS_BUILD_DIR $HOME/gopath/src/sourcegraph.com/sourcegraph/go-vcs
-  - export TRAVIS_BUILD_DIR=$HOME/gopath/src/sourcegraph.com/sourcegraph/go-vcs
+  - export GOPATH="$HOME/gopath" # Fix until https://github.com/travis-ci/travis-ci/issues/3439 is resolved.
+  - mkdir -p $GOPATH/src/sourcegraph.com/sourcegraph
+  - mv $TRAVIS_BUILD_DIR $GOPATH/src/sourcegraph.com/sourcegraph/go-vcs
+  - export TRAVIS_BUILD_DIR=$GOPATH/src/sourcegraph.com/sourcegraph/go-vcs
   # hg >~ 2.5 is needed, but Travis CI's Ubuntu 12.04 ships with hg ~2.0
   - sudo add-apt-repository -y ppa:mercurial-ppa/releases
   - sudo apt-get update -q
@@ -23,8 +24,8 @@ before_install:
 install:
   - cd $TRAVIS_BUILD_DIR
   - go get -t -v -d ./...
-  - cd $HOME/gopath/src/github.com/libgit2/git2go && git checkout next && git submodule update --init && cd $TRAVIS_BUILD_DIR
-  - make install
+  - cd $GOPATH/src/github.com/libgit2/git2go && git checkout next && git submodule update --init && make install && cd $TRAVIS_BUILD_DIR
+  - go install ./...
 
 script:
   - make test

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,4 @@
-.PHONY: install test docker-test
-
-install:
-	go get -d github.com/libgit2/git2go
-	cd `go list -f '{{.Dir}}' github.com/libgit2/git2go` && git submodule update --init && make install
-	go install ./vcs
+.PHONY: test docker-test
 
 test:
 	go test -ldflags "-extldflags=-L"`go list -f '{{.Dir}}' github.com/libgit2/git2go`/vendor/libgit2/build ./...

--- a/README.md
+++ b/README.md
@@ -15,14 +15,14 @@ Note: the public API is experimental and subject to change until further notice.
 Resolving dependencies
 ======================
 
-You will need cmake to compile [libgit2](https://libgit2.github.com).
+The faster libgit2 implementation of git depends on `git2go` on its `next` branch. To install it, you will [need](https://github.com/libgit2/git2go/tree/next#installing):
 
-To use the faster libgit2 implementation of git, install git2go on its
-`next` branch (run `git checkout origin/next && make install` in its
-repository root) first. You also need to install libssh2 for SSH
-support.
+- `cmake`
+- `pkg-config`
+- `libssh2`
+- `libgcrypt`
 
-Run `go get ./...` to resolve dependencies.
+Once you have those prerequisites, follow [these steps](https://github.com/libgit2/git2go/tree/next#from-next) to install `git2go` on `next` branch.
 
 For hg blame, you need to install hglib: `pip install python-hglib`.
 
@@ -30,11 +30,8 @@ For hg blame, you need to install hglib: `pip install python-hglib`.
 Installing
 ==========
 
-
 ```
-go get sourcegraph.com/sourcegraph/go-vcs/vcs
-cd $GOPATH/src/sourcegraph.com/sourcegraph/go-vcs
-make install
+go get -u sourcegraph.com/sourcegraph/go-vcs/vcs
 ```
 
 

--- a/vcs/git/clone_update.go
+++ b/vcs/git/clone_update.go
@@ -1,8 +1,12 @@
 package git
 
+// TODO: Fix the "gcrypt_init.c:5:1: warning: 'gcry_thread_cbs' is deprecated" warning
+//       and remove -Wno-deprecated-declarations, if possible.
+
 /*
-extern int _govcs_gcrypt_init();
+#cgo CFLAGS: -Wno-deprecated-declarations
 #cgo LDFLAGS: -lgcrypt
+extern int _govcs_gcrypt_init();
 */
 import "C"
 import (


### PR DESCRIPTION
- Mention that both `libssh2` and `libgcrypt` are hard prerequisites for
libgit2 implementation in advance of its installation.
- The Makefile "install" target was outdated (missing the `git checkout
next` step). In addition to that, it repeats the exact same steps as
described in Resolving Dependencies section, which is assumed to be
done by the time user gets to Installing section. I removed it since
it's unneeded and may cause confusion.
- Closes #43.