### PR TITLE
Add optional commit details to vcs.Branch.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ Note: the public API is experimental and subject to change until further notice.
 [![Build Status](https://travis-ci.org/sourcegraph/go-vcs.png?branch=master)](https://travis-ci.org/sourcegraph/go-vcs)
 [![status](https://sourcegraph.com/api/repos/sourcegraph.com/sourcegraph/go-vcs/.badges/status.png)](https://sourcegraph.com/sourcegraph.com/sourcegraph/go-vcs)
 
-
 Resolving dependencies
 ======================
 
@@ -26,7 +25,6 @@ Once you have those prerequisites, follow [these steps](https://github.com/libgi
 
 For hg blame, you need to install hglib: `pip install python-hglib`.
 
-
 Installing
 ==========
 
@@ -39,12 +37,12 @@ Implementation differences
 
 The goal is to have all supported backends at feature parity, but until then, consult this table for implementation differences.
 
-| Feature                                 | `git`                | `gitcmd`           | `hg`                 | `hgcmd`              |
-|-----------------------------------------|----------------------|--------------------|----------------------|----------------------|
-| `vcs.BranchesOptions.BehindAheadBranch` | :white_large_square: | :white_check_mark: | :white_large_square: | :white_large_square: |
+| Feature                               | git                  | gitcmd             | hg                   | hgcmd                |
+|---------------------------------------|----------------------|--------------------|----------------------|----------------------|
+| vcs.BranchesOptions.IncludeCommit     | :white_large_square: | :white_check_mark: | :white_large_square: | :white_large_square: |
+| vcs.BranchesOptions.BehindAheadBranch | :white_large_square: | :white_check_mark: | :white_large_square: | :white_large_square: |
 
 Contributions that fill in the gaps are welcome!
-
 
 Running tests
 =============
@@ -52,7 +50,6 @@ Running tests
 Run `go test ./vcs/...`. You may need to supply linker flags to link with libgit2. If you get a linker error, try running `make test` instead. If that doesn't work, check the command that `make test` runs to see if it is using the correct paths on your system.
 
 Note that the tests test the libgit2 implementation and SSH support (see above instructions).
-
 
 Contributors
 ============

--- a/vcs/gitcmd/repo.go
+++ b/vcs/gitcmd/repo.go
@@ -196,6 +196,16 @@ func (r *Repository) Branches(opt vcs.BranchesOptions) ([]*vcs.Branch, error) {
 		}
 	}
 
+	if opt.IncludeCommit {
+		for i, branch := range branches {
+			c, err := r.getCommit(branch.Head)
+			if err != nil {
+				return nil, err
+			}
+			branches[i].Commit = c
+		}
+	}
+
 	// Fetch behind/ahead counts for each branch.
 	if opt.BehindAheadBranch != "" {
 		for i, branch := range branches {
@@ -277,10 +287,7 @@ func exitStatus(err error) int {
 	return 0
 }
 
-func (r *Repository) GetCommit(id vcs.CommitID) (*vcs.Commit, error) {
-	r.editLock.RLock()
-	defer r.editLock.RUnlock()
-
+func (r *Repository) getCommit(id vcs.CommitID) (*vcs.Commit, error) {
 	if err := checkSpecArgSafety(string(id)); err != nil {
 		return nil, err
 	}
@@ -295,6 +302,13 @@ func (r *Repository) GetCommit(id vcs.CommitID) (*vcs.Commit, error) {
 	}
 
 	return commits[0], nil
+}
+
+func (r *Repository) GetCommit(id vcs.CommitID) (*vcs.Commit, error) {
+	r.editLock.RLock()
+	defer r.editLock.RUnlock()
+
+	return r.getCommit(id)
 }
 
 func (r *Repository) Commits(opt vcs.CommitsOptions) ([]*vcs.Commit, uint, error) {

--- a/vcs/gitcmd/repo.go
+++ b/vcs/gitcmd/repo.go
@@ -287,6 +287,7 @@ func exitStatus(err error) int {
 	return 0
 }
 
+// getCommit returns the commit with the given id. The caller must be holding r.editLock.
 func (r *Repository) getCommit(id vcs.CommitID) (*vcs.Commit, error) {
 	if err := checkSpecArgSafety(string(id)); err != nil {
 		return nil, err

--- a/vcs/repository.go
+++ b/vcs/repository.go
@@ -142,6 +142,15 @@ func (p Branches) Len() int           { return len(p) }
 func (p Branches) Less(i, j int) bool { return p[i].Name < p[j].Name }
 func (p Branches) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
 
+// ByAuthorDate sorts by author date. Requires full commit information to be included.
+type ByAuthorDate []*Branch
+
+func (p ByAuthorDate) Len() int { return len(p) }
+func (p ByAuthorDate) Less(i, j int) bool {
+	return p[i].Commit.Author.Date.Time().Before(p[j].Commit.Author.Date.Time())
+}
+func (p ByAuthorDate) Swap(i, j int) { p[i], p[j] = p[j], p[i] }
+
 type Tags []*Tag
 
 func (p Tags) Len() int           { return len(p) }

--- a/vcs/repository_test.go
+++ b/vcs/repository_test.go
@@ -492,56 +492,24 @@ func TestRepository_Branches_IncludeCommit(t *testing.T) {
 			repo: makeGitRepositoryCmd(t, gitCommands...),
 			wantBranches: []*vcs.Branch{
 				{
-					Name: (string)("master"),
-					Head: (vcs.CommitID)("a3c1537db9797215208eec56f8e7c9c37f8358ca"),
-					Commit: (*vcs.Commit)(&vcs.Commit{
-						ID: (vcs.CommitID)("a3c1537db9797215208eec56f8e7c9c37f8358ca"),
-						Author: (vcs.Signature)(vcs.Signature{
-							Name:  (string)("a"),
-							Email: (string)("a@a.com"),
-							Date: (pbtypes.Timestamp)(pbtypes.Timestamp{
-								Seconds: (int64)(1136214245),
-								Nanos:   (int32)(0),
-							}),
-						}),
-						Committer: (*vcs.Signature)(&vcs.Signature{
-							Name:  (string)("a"),
-							Email: (string)("a@a.com"),
-							Date: (pbtypes.Timestamp)(pbtypes.Timestamp{
-								Seconds: (int64)(1136214245),
-								Nanos:   (int32)(0),
-							}),
-						}),
-						Message: (string)("foo0"),
-						Parents: ([]vcs.CommitID)(nil),
-					}),
+					Name: "master", Head: "a3c1537db9797215208eec56f8e7c9c37f8358ca",
+					Commit: &vcs.Commit{
+						ID:        "a3c1537db9797215208eec56f8e7c9c37f8358ca",
+						Author:    vcs.Signature{"a", "a@a.com", mustParseTime(time.RFC3339, "2006-01-02T15:04:05Z")},
+						Committer: &vcs.Signature{"a", "a@a.com", mustParseTime(time.RFC3339, "2006-01-02T15:04:05Z")},
+						Message:   "foo0",
+						Parents:   nil,
+					},
 				},
 				{
-					Name: (string)("b0"),
-					Head: (vcs.CommitID)("c4a53701494d1d788b1ceeb8bf32e90224962473"),
-					Commit: (*vcs.Commit)(&vcs.Commit{
-						ID: (vcs.CommitID)("c4a53701494d1d788b1ceeb8bf32e90224962473"),
-						Author: (vcs.Signature)(vcs.Signature{
-							Name:  (string)("b"),
-							Email: (string)("b@b.com"),
-							Date: (pbtypes.Timestamp)(pbtypes.Timestamp{
-								Seconds: (int64)(1136214246),
-								Nanos:   (int32)(0),
-							}),
-						}),
-						Committer: (*vcs.Signature)(&vcs.Signature{
-							Name:  (string)("b"),
-							Email: (string)("b@b.com"),
-							Date: (pbtypes.Timestamp)(pbtypes.Timestamp{
-								Seconds: (int64)(1136214246),
-								Nanos:   (int32)(0),
-							}),
-						}),
-						Message: (string)("foo1"),
-						Parents: ([]vcs.CommitID)([]vcs.CommitID{
-							(vcs.CommitID)("a3c1537db9797215208eec56f8e7c9c37f8358ca"),
-						}),
-					}),
+					Name: "b0", Head: "c4a53701494d1d788b1ceeb8bf32e90224962473",
+					Commit: &vcs.Commit{
+						ID:        "c4a53701494d1d788b1ceeb8bf32e90224962473",
+						Author:    vcs.Signature{"b", "b@b.com", mustParseTime(time.RFC3339, "2006-01-02T15:04:06Z")},
+						Committer: &vcs.Signature{"b", "b@b.com", mustParseTime(time.RFC3339, "2006-01-02T15:04:06Z")},
+						Message:   "foo1",
+						Parents:   []vcs.CommitID{"a3c1537db9797215208eec56f8e7c9c37f8358ca"},
+					},
 				},
 			},
 		},

--- a/vcs/vcs.pb.go
+++ b/vcs/vcs.pb.go
@@ -78,6 +78,9 @@ type Branch struct {
 	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
 	// Head is the commit ID of this branch's head commit.
 	Head CommitID `protobuf:"bytes,2,opt,name=head,proto3,customtype=CommitID" json:"head,omitempty"`
+	// Commit optionally contains commit information for this branch's head commit.
+	// It is populated if IncludeCommit option is set.
+	Commit *Commit `protobuf:"bytes,4,opt,name=commit" json:"commit,omitempty"`
 	// Counts optionally contains the commit counts relative to specified branch.
 	Counts *BehindAhead `protobuf:"bytes,3,opt,name=counts" json:"counts,omitempty"`
 }
@@ -85,6 +88,13 @@ type Branch struct {
 func (m *Branch) Reset()         { *m = Branch{} }
 func (m *Branch) String() string { return proto.CompactTextString(m) }
 func (*Branch) ProtoMessage()    {}
+
+func (m *Branch) GetCommit() *Commit {
+	if m != nil {
+		return m.Commit
+	}
+	return nil
+}
 
 func (m *Branch) GetCounts() *BehindAhead {
 	if m != nil {
@@ -106,6 +116,8 @@ func (*BehindAhead) ProtoMessage()    {}
 // BranchesOptions specifies options for the list of branches returned by
 // (Repository).Branches.
 type BranchesOptions struct {
+	// IncludeCommit controls whether complete commit information is included.
+	IncludeCommit bool `protobuf:"varint,2,opt,name=include_commit,proto3" json:"include_commit,omitempty" url:",omitempty"`
 	// BehindAheadBranch specifies a branch name. If set to something other than blank
 	// string, then each returned branch will include a behind/ahead commit counts
 	// information against the specified base branch. If left blank, then branches will

--- a/vcs/vcs.proto
+++ b/vcs/vcs.proto
@@ -28,6 +28,10 @@ message Branch {
 	// Head is the commit ID of this branch's head commit.
 	string head = 2 [(gogoproto.customtype) = "CommitID"];
 
+	// Commit optionally contains commit information for this branch's head commit.
+	// It is populated if IncludeCommit option is set.
+	optional Commit commit = 4;
+
 	// Counts optionally contains the commit counts relative to specified branch.
 	optional BehindAhead counts = 3;
 }
@@ -41,6 +45,9 @@ message BehindAhead {
 // BranchesOptions specifies options for the list of branches returned by
 // (Repository).Branches.
 message BranchesOptions {
+	// IncludeCommit controls whether complete commit information is included.
+	bool include_commit = 2 [(gogoproto.moretags) = "url:\",omitempty\""];
+
 	// BehindAheadBranch specifies a branch name. If set to something other than blank
 	// string, then each returned branch will include a behind/ahead commit counts
 	// information against the specified base branch. If left blank, then branches will
@@ -93,4 +100,3 @@ message SearchResult {
 	// EndByte).
 	bytes match = 6;
 }
-


### PR DESCRIPTION
When calling vcs.Branches method, it is now possible to set IncludeCommit option to true. Doing so will include full commit details for each returned branch (i.e., the head commit for each branch).