### PR TITLE
Add support for file/dir history.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The goal is to have all supported backends at feature parity, but until then, co
 
 | Feature                               | git                  | gitcmd             | hg                   | hgcmd                |
 |---------------------------------------|----------------------|--------------------|----------------------|----------------------|
+| vcs.CommitsOptions.Path               | :white_large_square: | :white_check_mark: | :white_large_square: | :white_large_square: |
 | vcs.BranchesOptions.IncludeCommit     | :white_large_square: | :white_check_mark: | :white_large_square: | :white_large_square: |
 | vcs.BranchesOptions.BehindAheadBranch | :white_large_square: | :white_check_mark: | :white_large_square: | :white_large_square: |
 

--- a/vcs/gitcmd/repo.go
+++ b/vcs/gitcmd/repo.go
@@ -334,6 +334,9 @@ func isInvalidRevisionRangeError(output, obj string) bool {
 	return strings.HasPrefix(output, "fatal: Invalid revision range "+obj)
 }
 
+// commitLog returns a list of commits.
+//
+// The caller is responsible for doing checkSpecArgSafety on opt.Head and opt.Base.
 func (r *Repository) commitLog(opt vcs.CommitsOptions) ([]*vcs.Commit, uint, error) {
 	args := []string{"log", `--format=format:%H%x00%aN%x00%aE%x00%at%x00%cN%x00%cE%x00%ct%x00%B%x00%P%x00`}
 	if opt.N != 0 {
@@ -410,10 +413,8 @@ func (r *Repository) commitLog(opt vcs.CommitsOptions) ([]*vcs.Commit, uint, err
 	// Count commits.
 	cmd = exec.Command("git", "rev-list", "--count", rng)
 	if opt.Path != "" {
-		// TODO: This doesn't include --follow flag because rev-list doesn't support it, so the number may be slightly off.
-		//       Consider removing the "total" return value from the API altogether, that's why I'm not trying to do more to produce an accurate number here.
-		//       Getting the total number of commits is an expensive operation and likely isn't needed, or deserves a separate dedicated API if needed.
-		cmd = exec.Command("git", "rev-list", "--count", rng, "--", opt.Path)
+		// This doesn't include --follow flag because rev-list doesn't support it, so the number may be slightly off.
+		cmd.Args = append(cmd.Args, "--", opt.Path)
 	}
 	cmd.Dir = r.Dir
 	out, err = cmd.CombinedOutput()

--- a/vcs/repository.go
+++ b/vcs/repository.go
@@ -120,6 +120,8 @@ type CommitsOptions struct {
 
 	N    uint // limit the number of returned commits to this many (0 means no limit)
 	Skip uint // skip this many commits at the beginning
+
+	Path string // only commits modifying the given path are selected (optional)
 }
 
 // DiffOptions configures a diff.


### PR DESCRIPTION
- This is done by allowing to select only commits that modify a given path.
- The direction of this commit is largely based on research and findings from commit 2a71007acc73d25867c6e9e6a0e706b346b7336c. See it and its commit message for rationale.
- Minor fixes to ./cmd/go-vcs and improvements to code style consistency.

This is ready for initial review. /cc @sqs I may want to do some minor fixups and add tests tomorrow.