### PR TITLE
vcs/gitcmd: Ignore binary files for Search

### DIFF
--- a/vcs/gitcmd/repo.go
+++ b/vcs/gitcmd/repo.go
@@ -728,7 +728,7 @@ func (r *Repository) Search(at vcs.CommitID, opt vcs.SearchOptions) ([]*vcs.Sear
 		return nil, fmt.Errorf("unrecognized QueryType: %q", opt.QueryType)
 	}
 
-	cmd := exec.Command("git", "grep", "--null", "--line-number", "--no-color", "--context", strconv.Itoa(int(opt.ContextLines)), queryType, "-e", opt.Query, string(at))
+	cmd := exec.Command("git", "grep", "--null", "--line-number", "-I", "--no-color", "--context", strconv.Itoa(int(opt.ContextLines)), queryType, "-e", opt.Query, string(at))
 	cmd.Dir = r.Dir
 	cmd.Stderr = os.Stderr
 	out, err := cmd.StdoutPipe()


### PR DESCRIPTION
When there is a match in a binary file, the output of `git grep` does not much
what we expect, leading to a slice bounds out of range in
`gitcmd.(*Repository).Search`. The format of a binary match line is

  Binary file HASH:PATH/TO/BINARY/FILE matches