### PR TITLE
vcs/*: fix handling of root paths inside VFS backends

### DIFF
--- a/vcs/git/repo.go
+++ b/vcs/git/repo.go
@@ -593,6 +593,8 @@ func (fs *gitFSLibGit2) readFileBytes(name string) ([]byte, error) {
 }
 
 func (fs *gitFSLibGit2) Open(name string) (vfs.ReadSeekCloser, error) {
+	name = util.Rel(name)
+
 	fs.repoEditLock.RLock()
 	defer fs.repoEditLock.RUnlock()
 
@@ -607,7 +609,7 @@ func (fs *gitFSLibGit2) Lstat(path string) (os.FileInfo, error) {
 	fs.repoEditLock.RLock()
 	defer fs.repoEditLock.RUnlock()
 
-	path = filepath.Clean(path)
+	path = filepath.Clean(util.Rel(path))
 
 	mtime, err := fs.getModTime()
 	if err != nil {
@@ -636,7 +638,7 @@ func (fs *gitFSLibGit2) Stat(path string) (os.FileInfo, error) {
 	fs.repoEditLock.RLock()
 	defer fs.repoEditLock.RUnlock()
 
-	path = filepath.Clean(path)
+	path = filepath.Clean(util.Rel(path))
 
 	mtime, err := fs.getModTime()
 	if err != nil {
@@ -761,7 +763,7 @@ func (fs *gitFSLibGit2) ReadDir(path string) ([]os.FileInfo, error) {
 	fs.repoEditLock.RLock()
 	defer fs.repoEditLock.RUnlock()
 
-	path = filepath.Clean(path)
+	path = filepath.Clean(util.Rel(path))
 
 	var subtree *git2go.Tree
 	if path == "." {

--- a/vcs/git/repo.go
+++ b/vcs/git/repo.go
@@ -16,6 +16,7 @@ import (
 	"golang.org/x/tools/godoc/vfs"
 	"sourcegraph.com/sourcegraph/go-vcs/vcs"
 	"sourcegraph.com/sourcegraph/go-vcs/vcs/gitcmd"
+	"sourcegraph.com/sourcegraph/go-vcs/vcs/internal"
 	"sourcegraph.com/sourcegraph/go-vcs/vcs/util"
 	"sourcegraph.com/sqs/pbtypes"
 )
@@ -593,7 +594,7 @@ func (fs *gitFSLibGit2) readFileBytes(name string) ([]byte, error) {
 }
 
 func (fs *gitFSLibGit2) Open(name string) (vfs.ReadSeekCloser, error) {
-	name = util.Rel(name)
+	name = internal.Rel(name)
 
 	fs.repoEditLock.RLock()
 	defer fs.repoEditLock.RUnlock()
@@ -609,7 +610,7 @@ func (fs *gitFSLibGit2) Lstat(path string) (os.FileInfo, error) {
 	fs.repoEditLock.RLock()
 	defer fs.repoEditLock.RUnlock()
 
-	path = filepath.Clean(util.Rel(path))
+	path = filepath.Clean(internal.Rel(path))
 
 	mtime, err := fs.getModTime()
 	if err != nil {
@@ -638,7 +639,7 @@ func (fs *gitFSLibGit2) Stat(path string) (os.FileInfo, error) {
 	fs.repoEditLock.RLock()
 	defer fs.repoEditLock.RUnlock()
 
-	path = filepath.Clean(util.Rel(path))
+	path = filepath.Clean(internal.Rel(path))
 
 	mtime, err := fs.getModTime()
 	if err != nil {
@@ -763,7 +764,7 @@ func (fs *gitFSLibGit2) ReadDir(path string) ([]os.FileInfo, error) {
 	fs.repoEditLock.RLock()
 	defer fs.repoEditLock.RUnlock()
 
-	path = filepath.Clean(util.Rel(path))
+	path = filepath.Clean(internal.Rel(path))
 
 	var subtree *git2go.Tree
 	if path == "." {

--- a/vcs/gitcmd/repo.go
+++ b/vcs/gitcmd/repo.go
@@ -848,6 +848,7 @@ type gitFSCmd struct {
 }
 
 func (fs *gitFSCmd) Open(name string) (vfs.ReadSeekCloser, error) {
+	name = util.Rel(name)
 	fs.repoEditLock.RLock()
 	defer fs.repoEditLock.RUnlock()
 	b, err := fs.readFileBytes(name)
@@ -886,7 +887,7 @@ func (fs *gitFSCmd) Lstat(path string) (os.FileInfo, error) {
 	fs.repoEditLock.RLock()
 	defer fs.repoEditLock.RUnlock()
 
-	path = filepath.Clean(path)
+	path = filepath.Clean(util.Rel(path))
 
 	if path == "." {
 		// Special case root, which is not returned by `git ls-tree`.
@@ -931,6 +932,8 @@ func (fs *gitFSCmd) getModTimeFromGitLog(path string) (time.Time, error) {
 }
 
 func (fs *gitFSCmd) Stat(path string) (os.FileInfo, error) {
+	path = util.Rel(path)
+
 	fs.repoEditLock.RLock()
 	defer fs.repoEditLock.RUnlock()
 
@@ -958,7 +961,7 @@ func (fs *gitFSCmd) ReadDir(path string) ([]os.FileInfo, error) {
 	defer fs.repoEditLock.RUnlock()
 	// Trailing slash is necessary to ls-tree under the dir (not just
 	// to list the dir's tree entry in its parent dir).
-	return fs.lsTree(filepath.Clean(path) + "/")
+	return fs.lsTree(filepath.Clean(util.Rel(path)) + "/")
 }
 
 func (fs *gitFSCmd) lsTree(path string) ([]os.FileInfo, error) {

--- a/vcs/gitcmd/repo.go
+++ b/vcs/gitcmd/repo.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"sourcegraph.com/sourcegraph/go-vcs/vcs"
+	"sourcegraph.com/sourcegraph/go-vcs/vcs/internal"
 	"sourcegraph.com/sourcegraph/go-vcs/vcs/util"
 	"sourcegraph.com/sqs/pbtypes"
 
@@ -848,7 +849,7 @@ type gitFSCmd struct {
 }
 
 func (fs *gitFSCmd) Open(name string) (vfs.ReadSeekCloser, error) {
-	name = util.Rel(name)
+	name = internal.Rel(name)
 	fs.repoEditLock.RLock()
 	defer fs.repoEditLock.RUnlock()
 	b, err := fs.readFileBytes(name)
@@ -887,7 +888,7 @@ func (fs *gitFSCmd) Lstat(path string) (os.FileInfo, error) {
 	fs.repoEditLock.RLock()
 	defer fs.repoEditLock.RUnlock()
 
-	path = filepath.Clean(util.Rel(path))
+	path = filepath.Clean(internal.Rel(path))
 
 	if path == "." {
 		// Special case root, which is not returned by `git ls-tree`.
@@ -932,7 +933,7 @@ func (fs *gitFSCmd) getModTimeFromGitLog(path string) (time.Time, error) {
 }
 
 func (fs *gitFSCmd) Stat(path string) (os.FileInfo, error) {
-	path = util.Rel(path)
+	path = internal.Rel(path)
 
 	fs.repoEditLock.RLock()
 	defer fs.repoEditLock.RUnlock()
@@ -961,7 +962,7 @@ func (fs *gitFSCmd) ReadDir(path string) ([]os.FileInfo, error) {
 	defer fs.repoEditLock.RUnlock()
 	// Trailing slash is necessary to ls-tree under the dir (not just
 	// to list the dir's tree entry in its parent dir).
-	return fs.lsTree(filepath.Clean(util.Rel(path)) + "/")
+	return fs.lsTree(filepath.Clean(internal.Rel(path)) + "/")
 }
 
 func (fs *gitFSCmd) lsTree(path string) ([]os.FileInfo, error) {

--- a/vcs/hg/repo.go
+++ b/vcs/hg/repo.go
@@ -20,6 +20,7 @@ import (
 	"golang.org/x/tools/godoc/vfs"
 	"sourcegraph.com/sourcegraph/go-vcs/vcs"
 	"sourcegraph.com/sourcegraph/go-vcs/vcs/hgcmd"
+	"sourcegraph.com/sourcegraph/go-vcs/vcs/internal"
 	"sourcegraph.com/sourcegraph/go-vcs/vcs/util"
 	"sourcegraph.com/sqs/pbtypes"
 )
@@ -358,7 +359,7 @@ func (fs *hgFSNative) getEntry(path string) (*hg_revlog.Rec, *hg_store.ManifestE
 }
 
 func (fs *hgFSNative) Open(name string) (vfs.ReadSeekCloser, error) {
-	name = util.Rel(name)
+	name = internal.Rel(name)
 	rec, _, err := fs.getEntry(name)
 	if err != nil {
 		return nil, standardizeHgError(err)
@@ -396,7 +397,7 @@ func (fs *hgFSNative) Lstat(path string) (os.FileInfo, error) {
 }
 
 func (fs *hgFSNative) lstat(path string) (*util.FileInfo, []byte, error) {
-	path = filepath.Clean(util.Rel(path))
+	path = filepath.Clean(internal.Rel(path))
 
 	rec, ent, err := fs.getEntry(path)
 	if os.IsNotExist(err) {
@@ -422,7 +423,7 @@ func (fs *hgFSNative) lstat(path string) (*util.FileInfo, []byte, error) {
 }
 
 func (fs *hgFSNative) Stat(path string) (os.FileInfo, error) {
-	path = util.Rel(path)
+	path = internal.Rel(path)
 	fi, data, err := fs.lstat(path)
 	if err != nil {
 		return nil, err
@@ -502,7 +503,7 @@ func (fs *hgFSNative) fileInfo(ent *hg_store.ManifestEnt) *util.FileInfo {
 }
 
 func (fs *hgFSNative) ReadDir(path string) ([]os.FileInfo, error) {
-	path = util.Rel(path)
+	path = internal.Rel(path)
 	m, err := fs.getManifest(fs.at)
 	if err != nil {
 		return nil, err

--- a/vcs/hg/repo.go
+++ b/vcs/hg/repo.go
@@ -358,6 +358,7 @@ func (fs *hgFSNative) getEntry(path string) (*hg_revlog.Rec, *hg_store.ManifestE
 }
 
 func (fs *hgFSNative) Open(name string) (vfs.ReadSeekCloser, error) {
+	name = util.Rel(name)
 	rec, _, err := fs.getEntry(name)
 	if err != nil {
 		return nil, standardizeHgError(err)
@@ -395,7 +396,7 @@ func (fs *hgFSNative) Lstat(path string) (os.FileInfo, error) {
 }
 
 func (fs *hgFSNative) lstat(path string) (*util.FileInfo, []byte, error) {
-	path = filepath.Clean(path)
+	path = filepath.Clean(util.Rel(path))
 
 	rec, ent, err := fs.getEntry(path)
 	if os.IsNotExist(err) {
@@ -421,6 +422,7 @@ func (fs *hgFSNative) lstat(path string) (*util.FileInfo, []byte, error) {
 }
 
 func (fs *hgFSNative) Stat(path string) (os.FileInfo, error) {
+	path = util.Rel(path)
 	fi, data, err := fs.lstat(path)
 	if err != nil {
 		return nil, err
@@ -500,6 +502,7 @@ func (fs *hgFSNative) fileInfo(ent *hg_store.ManifestEnt) *util.FileInfo {
 }
 
 func (fs *hgFSNative) ReadDir(path string) ([]os.FileInfo, error) {
+	path = util.Rel(path)
 	m, err := fs.getManifest(fs.at)
 	if err != nil {
 		return nil, err

--- a/vcs/hgcmd/repo.go
+++ b/vcs/hgcmd/repo.go
@@ -18,6 +18,7 @@ import (
 
 	"sourcegraph.com/sourcegraph/go-diff/diff"
 	"sourcegraph.com/sourcegraph/go-vcs/vcs"
+	"sourcegraph.com/sourcegraph/go-vcs/vcs/internal"
 	"sourcegraph.com/sourcegraph/go-vcs/vcs/util"
 	"sourcegraph.com/sqs/pbtypes"
 
@@ -421,7 +422,7 @@ type hgFSCmd struct {
 }
 
 func (fs *hgFSCmd) Open(name string) (vfs.ReadSeekCloser, error) {
-	name = util.Rel(name)
+	name = internal.Rel(name)
 	cmd := exec.Command("hg", "cat", "--rev="+string(fs.at), "--", name)
 	cmd.Dir = fs.dir
 	out, err := cmd.CombinedOutput()
@@ -435,13 +436,13 @@ func (fs *hgFSCmd) Open(name string) (vfs.ReadSeekCloser, error) {
 }
 
 func (fs *hgFSCmd) Lstat(path string) (os.FileInfo, error) {
-	return fs.Stat(util.Rel(path))
+	return fs.Stat(internal.Rel(path))
 }
 
 func (fs *hgFSCmd) Stat(path string) (os.FileInfo, error) {
 	// TODO(sqs): follow symlinks (as Stat is required to do)
 
-	path = util.Rel(path)
+	path = internal.Rel(path)
 	var mtime time.Time
 
 	cmd := exec.Command("hg", "log", "-l1", `--template={date|date}`,
@@ -485,7 +486,7 @@ func (fs *hgFSCmd) Stat(path string) (os.FileInfo, error) {
 }
 
 func (fs *hgFSCmd) ReadDir(path string) ([]os.FileInfo, error) {
-	path = filepath.Clean(util.Rel(path))
+	path = filepath.Clean(internal.Rel(path))
 	// This combination of --include and --exclude opts gets all the files in
 	// the dir specified by path, plus all files one level deeper (but no
 	// deeper). This lets us list the files *and* subdirs in the dir without

--- a/vcs/hgcmd/repo.go
+++ b/vcs/hgcmd/repo.go
@@ -421,6 +421,7 @@ type hgFSCmd struct {
 }
 
 func (fs *hgFSCmd) Open(name string) (vfs.ReadSeekCloser, error) {
+	name = util.Rel(name)
 	cmd := exec.Command("hg", "cat", "--rev="+string(fs.at), "--", name)
 	cmd.Dir = fs.dir
 	out, err := cmd.CombinedOutput()
@@ -434,12 +435,13 @@ func (fs *hgFSCmd) Open(name string) (vfs.ReadSeekCloser, error) {
 }
 
 func (fs *hgFSCmd) Lstat(path string) (os.FileInfo, error) {
-	return fs.Stat(path)
+	return fs.Stat(util.Rel(path))
 }
 
 func (fs *hgFSCmd) Stat(path string) (os.FileInfo, error) {
 	// TODO(sqs): follow symlinks (as Stat is required to do)
 
+	path = util.Rel(path)
 	var mtime time.Time
 
 	cmd := exec.Command("hg", "log", "-l1", `--template={date|date}`,
@@ -483,7 +485,7 @@ func (fs *hgFSCmd) Stat(path string) (os.FileInfo, error) {
 }
 
 func (fs *hgFSCmd) ReadDir(path string) ([]os.FileInfo, error) {
-	path = filepath.Clean(path)
+	path = filepath.Clean(util.Rel(path))
 	// This combination of --include and --exclude opts gets all the files in
 	// the dir specified by path, plus all files one level deeper (but no
 	// deeper). This lets us list the files *and* subdirs in the dir without

--- a/vcs/internal/path.go
+++ b/vcs/internal/path.go
@@ -5,6 +5,9 @@ import "strings"
 // Rel strips the leading "/" prefix from the path string, effectively turning
 // an absolute path into one relative to the root directory. A path that is just
 // "/" is treated specially, returning just ".".
+//
+// The elements in a file path are separated by slash ('/', U+002F) characters,
+// regardless of host operating system convention.
 func Rel(path string) string {
 	if path == "/" {
 		return "."

--- a/vcs/internal/path.go
+++ b/vcs/internal/path.go
@@ -1,9 +1,10 @@
-package util
+package internal
 
 import "strings"
 
 // Rel strips the leading "/" prefix from the path string, effectively turning
-// an absolute path into one relative to the root directory.
+// an absolute path into one relative to the root directory. A path that is just
+// "/" is treated specially, returning just ".".
 func Rel(path string) string {
 	if path == "/" {
 		return "."

--- a/vcs/util/path.go
+++ b/vcs/util/path.go
@@ -5,5 +5,8 @@ import "strings"
 // Rel strips the leading "/" prefix from the path string, effectively turning
 // an absolute path into one relative to the root directory.
 func Rel(path string) string {
+	if path == "/" {
+		return "."
+	}
 	return strings.TrimPrefix(path, "/")
 }

--- a/vcs/util/path.go
+++ b/vcs/util/path.go
@@ -1,0 +1,10 @@
+package util
+
+// Rel strips the leading "/" prefix from the path string, effectively turning
+// an absolute path into one relative to the root directory.
+func Rel(path string) string {
+	if len(path) > 0 && path[0] == '/' {
+		return path[1:]
+	}
+	return path
+}

--- a/vcs/util/path.go
+++ b/vcs/util/path.go
@@ -1,10 +1,9 @@
 package util
 
+import "strings"
+
 // Rel strips the leading "/" prefix from the path string, effectively turning
 // an absolute path into one relative to the root directory.
 func Rel(path string) string {
-	if len(path) > 0 && path[0] == '/' {
-		return path[1:]
-	}
-	return path
+	return strings.TrimPrefix(path, "/")
 }


### PR DESCRIPTION
This change handles root paths (i.e. `/foo`) as if they were relative
(`foo`) such that asking the VFS for a file at the root works properly.

Without this change it is impossible to use the VFS provided with:

`golang.org/x/tools/godoc/vfs/httpfs`

As `net/http.FileSystem` will implicitly convert all URL paths into
absolute paths at the root of the FS.

Additionally this makes the behavior of the VFS backends comply with
the OS VFS implementation provided by the `godoc/vfs` package.

Fixes #23