### PR TITLE
vcs/git: update for recent changes to git2go

### DIFF
--- a/vcs/git/clone_update.go
+++ b/vcs/git/clone_update.go
@@ -45,10 +45,7 @@ func init() {
 }
 
 func Clone(url, dir string, opt vcs.CloneOpt) (vcs.Repository, error) {
-	clopt := git2go.CloneOptions{
-		FetchOptions: &git2go.FetchOptions{},
-		Bare:         opt.Bare,
-	}
+	clopt := git2go.CloneOptions{Bare: opt.Bare}
 
 	rc, cfs, err := makeRemoteCallbacks(url, opt.RemoteOpts)
 	if err != nil {
@@ -58,7 +55,7 @@ func Clone(url, dir string, opt vcs.CloneOpt) (vcs.Repository, error) {
 		defer cfs.run()
 	}
 	if rc != nil {
-		clopt.RemoteCallbacks = *rc
+		clopt.FetchOptions = &git2go.FetchOptions{RemoteCallbacks: *rc}
 	}
 
 	u, err := git2go.Clone(url, dir, &clopt)

--- a/vcs/git/repo.go
+++ b/vcs/git/repo.go
@@ -308,11 +308,11 @@ func (r *Repository) CrossRepoDiff(base vcs.CommitID, headRepo vcs.Repository, h
 // Callers must hold the r.editLock write lock.
 func (r *Repository) createAndFetchFromAnonRemote(repoDir string) (*git2go.Remote, error) {
 	name := base64.URLEncoding.EncodeToString([]byte(repoDir))
-	rem, err := r.u.CreateAnonymousRemote(repoDir, name)
+	rem, err := r.u.CreateAnonymousRemote(repoDir)
 	if err != nil {
 		return nil, err
 	}
-	if err := rem.Fetch([]string{"+refs/heads/*:refs/remotes/" + name + "/*"}, ""); err != nil {
+	if err := rem.Fetch([]string{"+refs/heads/*:refs/remotes/" + name + "/*"}, nil, ""); err != nil {
 		rem.Free()
 		return nil, err
 	}


### PR DESCRIPTION
This updates the usage of git2go to account for recent API changes in the `next` branch.

Fixes the Travis-ci build.