### PR TITLE
git: Use reverse chronological order in Commits method.

### DIFF
--- a/vcs/git/repo.go
+++ b/vcs/git/repo.go
@@ -202,7 +202,7 @@ func (r *Repository) Commits(opt vcs.CommitsOptions) ([]*vcs.Commit, uint, error
 	}
 	defer walk.Free()
 
-	walk.Sorting(git2go.SortTopological)
+	walk.Sorting(git2go.SortTime)
 
 	oid, err := git2go.NewOid(string(opt.Head))
 	if err != nil {


### PR DESCRIPTION
This results in both git backends to produce same ordering in Commits method.

Fixes #56.