### PR TITLE
Breaking change: Remove total count from Commits method.

### DIFF
--- a/cmd/go-vcs/go-vcs.go
+++ b/cmd/go-vcs/go-vcs.go
@@ -217,12 +217,12 @@ func main() {
 			log.Fatal(err)
 		}
 
-		commits, total, err := repo.Commits(vcs.CommitsOptions{Head: commitID, N: 250})
+		commits, err := repo.Commits(vcs.CommitsOptions{Head: commitID, N: 250})
 		if err != nil {
 			log.Fatal(err)
 		}
 
-		fmt.Printf("# Commits (%d total):\n", total)
+		fmt.Println("# Commits:")
 		for _, c := range commits {
 			printCommit(c)
 		}
@@ -366,12 +366,12 @@ func main() {
 			log.Fatal(err)
 		}
 
-		commits, total, err := repo.Commits(vcs.CommitsOptions{Head: commitID, N: 10, Path: path})
+		commits, err := repo.Commits(vcs.CommitsOptions{Head: commitID, N: 10, Path: path})
 		if err != nil {
 			log.Fatal(err)
 		}
 
-		fmt.Printf("# History (%d total):\n", total)
+		fmt.Println("# History:")
 		for _, c := range commits {
 			printCommit(c)
 		}

--- a/vcs/bench_test.go
+++ b/vcs/bench_test.go
@@ -307,7 +307,7 @@ type benchRepository interface {
 	ResolveRevision(string) (vcs.CommitID, error)
 	ResolveTag(string) (vcs.CommitID, error)
 	GetCommit(vcs.CommitID) (*vcs.Commit, error)
-	Commits(vcs.CommitsOptions) ([]*vcs.Commit, uint, error)
+	Commits(vcs.CommitsOptions) ([]*vcs.Commit, error)
 	FileSystem(vcs.CommitID) (vfs.FileSystem, error)
 }
 
@@ -399,7 +399,7 @@ func benchCommits(b *testing.B, openRepo func() benchRepository, tag string) {
 		return
 	}
 
-	_, _, err = r.Commits(vcs.CommitsOptions{Head: commitID})
+	_, err = r.Commits(vcs.CommitsOptions{Head: commitID})
 	if err != nil {
 		b.Errorf("Commits: %s", err)
 		return

--- a/vcs/git/repo.go
+++ b/vcs/git/repo.go
@@ -192,13 +192,13 @@ func (r *Repository) GetCommit(id vcs.CommitID) (*vcs.Commit, error) {
 
 var MaxCommits = 250
 
-func (r *Repository) Commits(opt vcs.CommitsOptions) ([]*vcs.Commit, uint, error) {
+func (r *Repository) Commits(opt vcs.CommitsOptions) ([]*vcs.Commit, error) {
 	r.editLock.RLock()
 	defer r.editLock.RUnlock()
 
 	walk, err := r.u.Walk()
 	if err != nil {
-		return nil, 0, err
+		return nil, err
 	}
 	defer walk.Free()
 
@@ -206,25 +206,25 @@ func (r *Repository) Commits(opt vcs.CommitsOptions) ([]*vcs.Commit, uint, error
 
 	oid, err := git2go.NewOid(string(opt.Head))
 	if err != nil {
-		return nil, 0, err
+		return nil, err
 	}
 	if err := walk.Push(oid); err != nil {
 		if git2go.IsErrorCode(err, git2go.ErrNotFound) {
-			return nil, 0, vcs.ErrCommitNotFound
+			return nil, vcs.ErrCommitNotFound
 		}
-		return nil, 0, err
+		return nil, err
 	}
 
 	if opt.Base != "" {
 		baseOID, err := git2go.NewOid(string(opt.Base))
 		if err != nil {
-			return nil, 0, err
+			return nil, err
 		}
 		if err := walk.Hide(baseOID); err != nil {
 			if git2go.IsErrorCode(err, git2go.ErrNotFound) {
-				return nil, 0, vcs.ErrCommitNotFound
+				return nil, vcs.ErrCommitNotFound
 			}
-			return nil, 0, err
+			return nil, err
 		}
 	}
 
@@ -238,10 +238,10 @@ func (r *Repository) Commits(opt vcs.CommitsOptions) ([]*vcs.Commit, uint, error
 		return total < uint(MaxCommits)
 	})
 	if err != nil {
-		return nil, 0, err
+		return nil, err
 	}
 
-	return commits, total, nil
+	return commits, nil
 }
 
 func (r *Repository) makeCommit(c *git2go.Commit) *vcs.Commit {

--- a/vcs/hg/repo.go
+++ b/vcs/hg/repo.go
@@ -149,18 +149,19 @@ func (r *Repository) Commits(opt vcs.CommitsOptions) ([]*vcs.Commit, error) {
 	}
 
 	var commits []*vcs.Commit
-	total := uint(0)
+	skip := opt.Skip
 	for ; ; rec = rec.Prev() {
-		if total >= opt.Skip && (opt.N == 0 || uint(len(commits)) < opt.N) {
+		if skip > 0 {
+			skip--
+		} else {
 			c, err := r.makeCommit(rec)
 			if err != nil {
 				return nil, err
 			}
 			commits = append(commits, c)
 		}
-		total++
 
-		if rec.IsStartOfBranch() {
+		if rec.IsStartOfBranch() || (opt.N != 0 && uint(len(commits)) >= opt.N) {
 			break
 		}
 	}

--- a/vcs/hg/repo.go
+++ b/vcs/hg/repo.go
@@ -142,10 +142,10 @@ func (r *Repository) GetCommit(id vcs.CommitID) (*vcs.Commit, error) {
 	return r.makeCommit(rec)
 }
 
-func (r *Repository) Commits(opt vcs.CommitsOptions) ([]*vcs.Commit, uint, error) {
+func (r *Repository) Commits(opt vcs.CommitsOptions) ([]*vcs.Commit, error) {
 	rec, err := r.getRec(opt.Head)
 	if err != nil {
-		return nil, 0, err
+		return nil, err
 	}
 
 	var commits []*vcs.Commit
@@ -154,7 +154,7 @@ func (r *Repository) Commits(opt vcs.CommitsOptions) ([]*vcs.Commit, uint, error
 		if total >= opt.Skip && (opt.N == 0 || uint(len(commits)) < opt.N) {
 			c, err := r.makeCommit(rec)
 			if err != nil {
-				return nil, 0, err
+				return nil, err
 			}
 			commits = append(commits, c)
 		}
@@ -164,7 +164,7 @@ func (r *Repository) Commits(opt vcs.CommitsOptions) ([]*vcs.Commit, uint, error
 			break
 		}
 	}
-	return commits, total, nil
+	return commits, nil
 }
 
 func (r *Repository) makeCommit(rec *hg_revlog.Rec) (*vcs.Commit, error) {

--- a/vcs/repository.go
+++ b/vcs/repository.go
@@ -36,10 +36,8 @@ type Repository interface {
 	// ErrCommitNotFound if no such commit exists.
 	GetCommit(CommitID) (*Commit, error)
 
-	// Commits returns all commits matching the options, as well as
-	// the total number of commits (the count of which is not subject
-	// to the N/Skip options).
-	Commits(CommitsOptions) (commits []*Commit, total uint, err error)
+	// Commits returns all commits matching the options.
+	Commits(CommitsOptions) (commits []*Commit, err error)
 
 	// FileSystem opens the repository file tree at a given commit ID.
 	//

--- a/vcs/repository_test.go
+++ b/vcs/repository_test.go
@@ -704,47 +704,38 @@ func TestRepository_Commits(t *testing.T) {
 	}
 	tests := map[string]struct {
 		repo interface {
-			Commits(opt vcs.CommitsOptions) ([]*vcs.Commit, uint, error)
+			Commits(opt vcs.CommitsOptions) ([]*vcs.Commit, error)
 		}
 		id          vcs.CommitID
 		wantCommits []*vcs.Commit
-		wantTotal   uint
 	}{
 		"git libgit2": {
 			repo:        makeGitRepositoryLibGit2(t, gitCommands...),
 			id:          "b266c7e3ca00b1a17ad0b1449825d0854225c007",
 			wantCommits: wantGitCommits,
-			wantTotal:   2,
 		},
 		"git cmd": {
 			repo:        makeGitRepositoryCmd(t, gitCommands...),
 			id:          "b266c7e3ca00b1a17ad0b1449825d0854225c007",
 			wantCommits: wantGitCommits,
-			wantTotal:   2,
 		},
 		"hg native": {
 			repo:        makeHgRepositoryNative(t, hgCommands...),
 			id:          "c6320cdba5ebc6933bd7c94751dcd633d6aa0759",
 			wantCommits: wantHgCommits,
-			wantTotal:   2,
 		},
 		"hg cmd": {
 			repo:        makeHgRepositoryCmd(t, hgCommands...),
 			id:          "c6320cdba5ebc6933bd7c94751dcd633d6aa0759",
 			wantCommits: wantHgCommits,
-			wantTotal:   2,
 		},
 	}
 
 	for label, test := range tests {
-		commits, total, err := test.repo.Commits(vcs.CommitsOptions{Head: test.id})
+		commits, err := test.repo.Commits(vcs.CommitsOptions{Head: test.id})
 		if err != nil {
 			t.Errorf("%s: Commits: %s", label, err)
 			continue
-		}
-
-		if total != test.wantTotal {
-			t.Errorf("%s: got %d total commits, want %d", label, total, test.wantTotal)
 		}
 
 		if len(commits) != len(test.wantCommits) {
@@ -765,7 +756,7 @@ func TestRepository_Commits(t *testing.T) {
 		}
 
 		// Test that trying to get a nonexistent commit returns ErrCommitNotFound.
-		if _, _, err := test.repo.Commits(vcs.CommitsOptions{Head: nonexistentCommitID}); err != vcs.ErrCommitNotFound {
+		if _, err := test.repo.Commits(vcs.CommitsOptions{Head: nonexistentCommitID}); err != vcs.ErrCommitNotFound {
 			t.Errorf("%s: for nonexistent commit: got err %v, want %v", label, err, vcs.ErrCommitNotFound)
 		}
 	}
@@ -818,23 +809,20 @@ func TestRepository_Commits_options(t *testing.T) {
 	}
 	tests := map[string]struct {
 		repo interface {
-			Commits(opt vcs.CommitsOptions) ([]*vcs.Commit, uint, error)
+			Commits(opt vcs.CommitsOptions) ([]*vcs.Commit, error)
 		}
 		opt         vcs.CommitsOptions
 		wantCommits []*vcs.Commit
-		wantTotal   uint
 	}{
 		"git libgit2": {
 			repo:        makeGitRepositoryLibGit2(t, gitCommands...),
 			opt:         vcs.CommitsOptions{Head: "ade564eba4cf904492fb56dcd287ac633e6e082c", N: 1, Skip: 1},
 			wantCommits: wantGitCommits,
-			wantTotal:   3,
 		},
 		"git cmd": {
 			repo:        makeGitRepositoryCmd(t, gitCommands...),
 			opt:         vcs.CommitsOptions{Head: "ade564eba4cf904492fb56dcd287ac633e6e082c", N: 1, Skip: 1},
 			wantCommits: wantGitCommits,
-			wantTotal:   3,
 		},
 		"git libgit2 Head": {
 			repo: makeGitRepositoryLibGit2(t, gitCommands...),
@@ -843,7 +831,6 @@ func TestRepository_Commits_options(t *testing.T) {
 				Base: "b266c7e3ca00b1a17ad0b1449825d0854225c007",
 			},
 			wantCommits: wantGitCommits2,
-			wantTotal:   1,
 		},
 		"git cmd Head": {
 			repo: makeGitRepositoryCmd(t, gitCommands...),
@@ -852,31 +839,24 @@ func TestRepository_Commits_options(t *testing.T) {
 				Base: "b266c7e3ca00b1a17ad0b1449825d0854225c007",
 			},
 			wantCommits: wantGitCommits2,
-			wantTotal:   1,
 		},
 		"hg native": {
 			repo:        makeHgRepositoryNative(t, hgCommands...),
 			opt:         vcs.CommitsOptions{Head: "443def46748a0c02c312bb4fdc6231d6ede45f49", N: 1, Skip: 1},
 			wantCommits: wantHgCommits,
-			wantTotal:   3,
 		},
 		"hg cmd": {
 			repo:        makeHgRepositoryCmd(t, hgCommands...),
 			opt:         vcs.CommitsOptions{Head: "443def46748a0c02c312bb4fdc6231d6ede45f49", N: 1, Skip: 1},
 			wantCommits: wantHgCommits,
-			wantTotal:   3,
 		},
 	}
 
 	for label, test := range tests {
-		commits, total, err := test.repo.Commits(test.opt)
+		commits, err := test.repo.Commits(test.opt)
 		if err != nil {
 			t.Errorf("%s: Commits(): %s", label, err)
 			continue
-		}
-
-		if total != test.wantTotal {
-			t.Errorf("%s: got %d total commits, want %d", label, total, test.wantTotal)
 		}
 
 		if len(commits) != len(test.wantCommits) {
@@ -920,11 +900,10 @@ func TestRepository_Commits_options_path(t *testing.T) {
 	}
 	tests := map[string]struct {
 		repo interface {
-			Commits(opt vcs.CommitsOptions) ([]*vcs.Commit, uint, error)
+			Commits(opt vcs.CommitsOptions) ([]*vcs.Commit, error)
 		}
 		opt         vcs.CommitsOptions
 		wantCommits []*vcs.Commit
-		wantTotal   uint
 	}{
 		"git cmd Path 0": {
 			repo: makeGitRepositoryCmd(t, gitCommands...),
@@ -933,7 +912,6 @@ func TestRepository_Commits_options_path(t *testing.T) {
 				Path: "doesnt-exist",
 			},
 			wantCommits: nil,
-			wantTotal:   0,
 		},
 		"git cmd Path 1": {
 			repo: makeGitRepositoryCmd(t, gitCommands...),
@@ -942,19 +920,14 @@ func TestRepository_Commits_options_path(t *testing.T) {
 				Path: "file1",
 			},
 			wantCommits: wantGitCommits,
-			wantTotal:   1,
 		},
 	}
 
 	for label, test := range tests {
-		commits, total, err := test.repo.Commits(test.opt)
+		commits, err := test.repo.Commits(test.opt)
 		if err != nil {
 			t.Errorf("%s: Commits(): %s", label, err)
 			continue
-		}
-
-		if total != test.wantTotal {
-			t.Errorf("%s: got %d total commits, want %d", label, total, test.wantTotal)
 		}
 
 		if len(commits) != len(test.wantCommits) {

--- a/vcs/testing/mock_repository.go
+++ b/vcs/testing/mock_repository.go
@@ -14,7 +14,7 @@ type MockRepository struct {
 	Tags_     func() ([]*vcs.Tag, error)
 
 	GetCommit_ func(vcs.CommitID) (*vcs.Commit, error)
-	Commits_   func(vcs.CommitsOptions) ([]*vcs.Commit, uint, error)
+	Commits_   func(vcs.CommitsOptions) ([]*vcs.Commit, error)
 
 	BlameFile_ func(path string, opt *vcs.BlameOptions) ([]*vcs.Hunk, error)
 
@@ -58,7 +58,7 @@ func (r MockRepository) GetCommit(id vcs.CommitID) (*vcs.Commit, error) {
 	return r.GetCommit_(id)
 }
 
-func (r MockRepository) Commits(opt vcs.CommitsOptions) ([]*vcs.Commit, uint, error) {
+func (r MockRepository) Commits(opt vcs.CommitsOptions) ([]*vcs.Commit, error) {
 	return r.Commits_(opt)
 }
 


### PR DESCRIPTION
The total commit count did not respect CommitOptions. In many backends, it performed completely separate, potentially expensive logic.

Many users of Commits discard the total count, resulting in wasted potentially expensive calculations. It makes most sense to have it available in a separate endpoint (with separate options) for interested parties. Begin by removing it from Commits method.

This is a breaking change, but I believe it leads to a better, simpler future API. Comments welcome.