### PR TITLE
Add CommitsOptions.NoTotal field to avoid calculating total.

### DIFF
--- a/vcs/git/repo.go
+++ b/vcs/git/repo.go
@@ -190,8 +190,6 @@ func (r *Repository) GetCommit(id vcs.CommitID) (*vcs.Commit, error) {
 	return r.makeCommit(c), nil
 }
 
-var MaxCommits = 250
-
 func (r *Repository) Commits(opt vcs.CommitsOptions) ([]*vcs.Commit, uint, error) {
 	r.editLock.RLock()
 	defer r.editLock.RUnlock()
@@ -235,10 +233,18 @@ func (r *Repository) Commits(opt vcs.CommitsOptions) ([]*vcs.Commit, uint, error
 			commits = append(commits, r.makeCommit(c))
 		}
 		total++
-		return total < uint(MaxCommits)
+		// If we want total, keep going until the end.
+		if opt.NoTotal == false {
+			return true
+		}
+		// Otherwise return once N has been satisfied.
+		return (opt.N == 0 || uint(len(commits)) < opt.N)
 	})
 	if err != nil {
 		return nil, 0, err
+	}
+	if opt.NoTotal {
+		total = 0
 	}
 
 	return commits, total, nil

--- a/vcs/git/repo.go
+++ b/vcs/git/repo.go
@@ -234,7 +234,7 @@ func (r *Repository) Commits(opt vcs.CommitsOptions) ([]*vcs.Commit, uint, error
 		}
 		total++
 		// If we want total, keep going until the end.
-		if opt.NoTotal == false {
+		if !opt.NoTotal {
 			return true
 		}
 		// Otherwise return once N has been satisfied.

--- a/vcs/gitcmd/repo.go
+++ b/vcs/gitcmd/repo.go
@@ -414,7 +414,7 @@ func (r *Repository) commitLog(opt vcs.CommitsOptions) ([]*vcs.Commit, uint, err
 
 	// Count commits.
 	var total uint
-	if opt.NoTotal == false {
+	if !opt.NoTotal {
 		cmd = exec.Command("git", "rev-list", "--count", rng)
 		if opt.Path != "" {
 			// This doesn't include --follow flag because rev-list doesn't support it, so the number may be slightly off.

--- a/vcs/hg/repo.go
+++ b/vcs/hg/repo.go
@@ -163,6 +163,17 @@ func (r *Repository) Commits(opt vcs.CommitsOptions) ([]*vcs.Commit, uint, error
 		if rec.IsStartOfBranch() {
 			break
 		}
+		// If we want total, keep going until the end.
+		if opt.NoTotal == false {
+			continue
+		}
+		// Otherwise return once N has been satisfied.
+		if opt.N != 0 && uint(len(commits)) >= opt.N {
+			break
+		}
+	}
+	if opt.NoTotal {
+		total = 0
 	}
 	return commits, total, nil
 }

--- a/vcs/hg/repo.go
+++ b/vcs/hg/repo.go
@@ -164,7 +164,7 @@ func (r *Repository) Commits(opt vcs.CommitsOptions) ([]*vcs.Commit, uint, error
 			break
 		}
 		// If we want total, keep going until the end.
-		if opt.NoTotal == false {
+		if !opt.NoTotal {
 			continue
 		}
 		// Otherwise return once N has been satisfied.

--- a/vcs/hgcmd/repo.go
+++ b/vcs/hgcmd/repo.go
@@ -242,7 +242,7 @@ func (r *Repository) commitLog(opt vcs.CommitsOptions) ([]*vcs.Commit, uint, err
 
 	// Count commits.
 	var total uint
-	if opt.NoTotal == false {
+	if !opt.NoTotal {
 		cmd = exec.Command("hg", "id", "--num", "--rev="+revSpec)
 		cmd.Dir = r.Dir
 		out, err = cmd.CombinedOutput()

--- a/vcs/hgcmd/repo.go
+++ b/vcs/hgcmd/repo.go
@@ -168,7 +168,7 @@ func (r *Repository) execAndParseCols(subcmd string) ([][2]string, error) {
 }
 
 func (r *Repository) GetCommit(id vcs.CommitID) (*vcs.Commit, error) {
-	commits, _, err := r.commitLog(string(id), 1)
+	commits, _, err := r.commitLog(vcs.CommitsOptions{Head: id, N: 1, NoTotal: true})
 	if err != nil {
 		return nil, err
 	}
@@ -181,16 +181,7 @@ func (r *Repository) GetCommit(id vcs.CommitID) (*vcs.Commit, error) {
 }
 
 func (r *Repository) Commits(opt vcs.CommitsOptions) ([]*vcs.Commit, uint, error) {
-	head := string(opt.Head)
-	if opt.Skip != 0 {
-		head += "~" + strconv.FormatUint(uint64(opt.N), 10)
-	}
-	commits, total, err := r.commitLog(head, opt.N)
-
-	// Add back however many we skipped.
-	total += opt.Skip
-
-	return commits, total, err
+	return r.commitLog(opt)
 }
 
 var hgNullParentNodeID = []byte("0000000000000000000000000000000000000000")
@@ -199,10 +190,15 @@ func isUnknownRevisionError(output, revSpec string) bool {
 	return output == "abort: unknown revision '"+string(revSpec)+"'!"
 }
 
-func (r *Repository) commitLog(revSpec string, n uint) ([]*vcs.Commit, uint, error) {
+func (r *Repository) commitLog(opt vcs.CommitsOptions) ([]*vcs.Commit, uint, error) {
+	revSpec := string(opt.Head)
+	if opt.Skip != 0 {
+		revSpec += "~" + strconv.FormatUint(uint64(opt.N), 10)
+	}
+
 	args := []string{"log", `--template={node}\x00{author|person}\x00{author|email}\x00{date|rfc3339date}\x00{desc}\x00{p1node}\x00{p2node}\x00`}
-	if n != 0 {
-		args = append(args, "--limit", strconv.FormatUint(uint64(n), 10))
+	if opt.N != 0 {
+		args = append(args, "--limit", strconv.FormatUint(uint64(opt.N), 10))
 	}
 	args = append(args, "--rev="+revSpec+":0")
 
@@ -244,21 +240,32 @@ func (r *Repository) commitLog(revSpec string, n uint) ([]*vcs.Commit, uint, err
 		}
 	}
 
-	// Count.
-	cmd = exec.Command("hg", "id", "--num", "--rev="+revSpec)
-	cmd.Dir = r.Dir
-	out, err = cmd.CombinedOutput()
-	if err != nil {
-		return nil, 0, fmt.Errorf("exec `hg id --num` failed: %s. Output was:\n\n%s", err, out)
-	}
-	out = bytes.TrimSpace(out)
-	total, err := strconv.ParseUint(string(out), 10, 64)
-	if err != nil {
-		return nil, 0, err
-	}
-	total++ // sequence number is 1 less than total number of commits
+	// Count commits.
+	var total uint
+	if opt.NoTotal == false {
+		cmd = exec.Command("hg", "id", "--num", "--rev="+revSpec)
+		cmd.Dir = r.Dir
+		out, err = cmd.CombinedOutput()
+		if err != nil {
+			return nil, 0, fmt.Errorf("exec `hg id --num` failed: %s. Output was:\n\n%s", err, out)
+		}
+		out = bytes.TrimSpace(out)
+		total, err = parseUint(string(out))
+		if err != nil {
+			return nil, 0, err
+		}
+		total++ // sequence number is 1 less than total number of commits
 
-	return commits, uint(total), nil
+		// Add back however many we skipped.
+		total += opt.Skip
+	}
+
+	return commits, total, nil
+}
+
+func parseUint(s string) (uint, error) {
+	n, err := strconv.ParseUint(s, 10, 64)
+	return uint(n), err
 }
 
 func (r *Repository) getParents(revSpec vcs.CommitID) ([]vcs.CommitID, error) {

--- a/vcs/repository.go
+++ b/vcs/repository.go
@@ -36,9 +36,12 @@ type Repository interface {
 	// ErrCommitNotFound if no such commit exists.
 	GetCommit(CommitID) (*Commit, error)
 
-	// Commits returns all commits matching the options, and optionally
+	// Commits returns all commits matching the options, as well as
 	// the total number of commits (the count of which is not subject
 	// to the N/Skip options).
+	//
+	// Optionally, the caller can request the total not to be computed,
+	// as this can be expensive.
 	Commits(CommitsOptions) (commits []*Commit, total uint, err error)
 
 	// FileSystem opens the repository file tree at a given commit ID.

--- a/vcs/repository.go
+++ b/vcs/repository.go
@@ -41,7 +41,7 @@ type Repository interface {
 	// to the N/Skip options).
 	//
 	// Optionally, the caller can request the total not to be computed,
-	// as this can be expensive.
+	// as this can be expensive for large branches.
 	Commits(CommitsOptions) (commits []*Commit, total uint, err error)
 
 	// FileSystem opens the repository file tree at a given commit ID.

--- a/vcs/repository.go
+++ b/vcs/repository.go
@@ -36,7 +36,7 @@ type Repository interface {
 	// ErrCommitNotFound if no such commit exists.
 	GetCommit(CommitID) (*Commit, error)
 
-	// Commits returns all commits matching the options, as well as
+	// Commits returns all commits matching the options, and optionally
 	// the total number of commits (the count of which is not subject
 	// to the N/Skip options).
 	Commits(CommitsOptions) (commits []*Commit, total uint, err error)
@@ -122,6 +122,8 @@ type CommitsOptions struct {
 	Skip uint // skip this many commits at the beginning
 
 	Path string // only commits modifying the given path are selected (optional)
+
+	NoTotal bool // avoid counting the total number of commits
 }
 
 // DiffOptions configures a diff.


### PR DESCRIPTION
This is an alternative implementation of the potential performance improvement proposed in #58. This time it's a non-breaking API change, adding a field that lets users not interested in `total` to opt out of calculating it.

Closes #58 because it offers the same functionality addition, done through a different API (non-breaking).