### PR TITLE
gitcmd: Avoid lsTree doing a double lock.

### DIFF
--- a/vcs/gitcmd/repo.go
+++ b/vcs/gitcmd/repo.go
@@ -1010,10 +1010,8 @@ func (fs *gitFSCmd) ReadDir(path string) ([]os.FileInfo, error) {
 	return fs.lsTree(filepath.Clean(internal.Rel(path)) + "/")
 }
 
+// lsTree returns ls of tree at path. The caller must be holding fs.repoEditLock.RLock().
 func (fs *gitFSCmd) lsTree(path string) ([]os.FileInfo, error) {
-	fs.repoEditLock.RLock()
-	defer fs.repoEditLock.RUnlock()
-
 	// Don't call filepath.Clean(path) because ReadDir needs to pass
 	// path with a trailing slash.
 


### PR DESCRIPTION
There are only 2 callers of `lsTree` in this package. Both of them already acquire and hold the `fs.repoEditLock.RLock()` when calling `lsTree`.

Remove `lsTree` doing a double lock and document it as requiring caller to hold the lock.