### PR TITLE
Revert skipping git2go ssh tests since upstream issue resolved.

### DIFF
--- a/vcs/ssh_test.go
+++ b/vcs/ssh_test.go
@@ -34,9 +34,6 @@ func startGitShellSSHServer(t *testing.T, label string, dir string) (*ssh.Server
 }
 
 func TestRepository_Clone_ssh(t *testing.T) {
-	// TODO: Do not skip this test once https://github.com/libgit2/git2go/issues/218 is resolved.
-	t.Skip("currently panicking due to upstream bug")
-
 	t.Parallel()
 
 	gitCommands := []string{
@@ -106,9 +103,6 @@ func TestRepository_Clone_ssh(t *testing.T) {
 }
 
 func TestRepository_UpdateEverything_ssh(t *testing.T) {
-	// TODO: Do not skip this test once https://github.com/libgit2/git2go/issues/218 is resolved.
-	t.Skip("currently panicking due to upstream bug")
-
 	t.Parallel()
 
 	// TODO(sqs): this test has a lot of overlap with


### PR DESCRIPTION
This reverts commit 9c3be6693258f5dfe68403c5f885d9dd6537491f.

Issue https://github.com/libgit2/git2go/issues/218 has been resolved and these tests should pass now.

It's a follow up to https://github.com/sourcegraph/go-vcs/pull/61#issuecomment-123152613 (/cc @slimsag).