### PR TITLE
Fetch list of committers in a repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The goal is to have all supported backends at feature parity, but until then, co
 | vcs.BranchesOptions.MergedInto        | :white_large_square: | :white_check_mark: | :white_large_square: | :white_large_square: |
 | vcs.BranchesOptions.IncludeCommit     | :white_large_square: | :white_check_mark: | :white_large_square: | :white_large_square: |
 | vcs.BranchesOptions.BehindAheadBranch | :white_large_square: | :white_check_mark: | :white_large_square: | :white_large_square: |
+| vcs.Repository.Committers             | :white_large_square: | :white_check_mark: | :white_large_square: | :white_large_square: |
 
 Contributions that fill in the gaps are welcome!
 

--- a/cmd/go-vcs/go-vcs.go
+++ b/cmd/go-vcs/go-vcs.go
@@ -420,6 +420,32 @@ func main() {
 		for _, c := range commits {
 			printCommit(c)
 		}
+
+	case "committers":
+		if len(args) != 0 {
+			log.Fatal("committers takes no arguments.")
+		}
+
+		// Open using go/vcs to figure out VCS type (git, hg).
+		r := vcs2.New(".")
+		if r == nil {
+			log.Fatalln("no supported vcs found in cwd")
+		}
+
+		repo, err := vcs.Open(r.Type().VcsType(), r.RootPath())
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		committers, err := repo.Committers()
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		fmt.Printf("# Committers (%d total):\n", len(committers))
+		for _, c := range committers {
+			fmt.Printf("%s <%s> has %v commits\n", c.Name, c.Email, c.Commits)
+		}
 	}
 }
 

--- a/cmd/go-vcs/go-vcs.go
+++ b/cmd/go-vcs/go-vcs.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"time"
 
 	"strings"
@@ -422,8 +423,20 @@ func main() {
 		}
 
 	case "committers":
-		if len(args) != 0 {
-			log.Fatal("committers takes no arguments.")
+		if len(args) > 2 {
+			log.Fatal("committers takes at most 2 arguments.")
+		}
+
+		var opt vcs.CommittersOptions
+		if len(args) > 0 {
+			opt.Rev = args[0]
+		}
+		if len(args) > 1 {
+			var err error
+			opt.N, err = strconv.Atoi(args[1])
+			if err != nil {
+				log.Fatal(err)
+			}
 		}
 
 		// Open using go/vcs to figure out VCS type (git, hg).
@@ -437,7 +450,7 @@ func main() {
 			log.Fatal(err)
 		}
 
-		committers, err := repo.Committers()
+		committers, err := repo.Committers(opt)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/vcs/gitcmd/repo.go
+++ b/vcs/gitcmd/repo.go
@@ -905,23 +905,22 @@ func (r *Repository) Committers() ([]*vcs.Committer, error) {
 
 	cmd := exec.Command("git", "shortlog", "-sne")
 	cmd.Dir = r.Dir
-	var outb, errb bytes.Buffer
-	cmd.Stdout = &outb
-	cmd.Stderr = &errb
-	if err := cmd.Run(); err != nil {
-		return nil, fmt.Errorf("exec `git shortlog -sne` failed: %s. Stderr was:\n\n%s", err, errb.Bytes())
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("exec `git shortlog -sne` failed: %v. Output was:\n\n%s", err, string(out))
 	}
+	log.Printf("command output: %v", string(out))
+	out = bytes.TrimSpace(out)
 
+	allEntries := bytes.Split(out, []byte{'\n'})
+	numEntries := len(allEntries)
 	var committers []*vcs.Committer
-	for {
-		outputLine, err := outb.ReadString('\n')
-		// check for a match in the returned string before checking err != nil
-		// since if err == io.EOF, then the returned string will contain
-		// the last line of the output.
-		if match := logEntryPattern.FindStringSubmatch(outputLine); match != nil {
+	for i := 0; i < numEntries; i++ {
+		line := string(allEntries[i])
+		if match := logEntryPattern.FindStringSubmatch(line); match != nil {
 			commits, err2 := strconv.Atoi(match[1])
 			if err2 != nil {
-				return nil, err2
+				continue
 			}
 			committers = append(committers, &vcs.Committer{
 				Commits: int32(commits),
@@ -929,15 +928,7 @@ func (r *Repository) Committers() ([]*vcs.Committer, error) {
 				Email:   match[3],
 			})
 		}
-		if err != nil {
-			if err == io.EOF {
-				break
-			} else {
-				return nil, err
-			}
-		}
 	}
-
 	return committers, nil
 }
 

--- a/vcs/gitcmd/repo.go
+++ b/vcs/gitcmd/repo.go
@@ -28,14 +28,10 @@ import (
 	"golang.org/x/tools/godoc/vfs"
 )
 
-const (
-	// LogEntryPattern is the regexp pattern that matches entries in the output of
-	// the `git shortlog -sne` command.
-	LogEntryPattern = `\s*([0-9]+)\s+([A-Za-z]+(?:\s[A-Za-z]+)*)\s+<([A-Za-z@.]+)>\s*`
-)
-
 var (
-	logEntryPattern = regexp.MustCompile("^" + LogEntryPattern + "$")
+	// logEntryPattern is the regexp pattern that matches entries in the output of
+	// the `git shortlog -sne` command.
+	logEntryPattern = regexp.MustCompile(`^\s*([0-9]+)\s+([A-Za-z]+(?:\s[A-Za-z]+)*)\s+<([A-Za-z@.]+)>\s*$`)
 )
 
 func init() {
@@ -909,9 +905,9 @@ func (r *Repository) Committers(opt vcs.CommittersOptions) ([]*vcs.Committer, er
 
 	cmd := exec.Command("git", "shortlog", "-sne", opt.Rev)
 	cmd.Dir = r.Dir
-	out, err := cmd.CombinedOutput()
+	out, err := cmd.Output()
 	if err != nil {
-		return nil, fmt.Errorf("exec `git shortlog -sne` failed: %v. Output was:\n\n%s", err, string(out))
+		return nil, fmt.Errorf("exec `git shortlog -sne` failed: %v", err)
 	}
 	out = bytes.TrimSpace(out)
 

--- a/vcs/gitcmd/repo.go
+++ b/vcs/gitcmd/repo.go
@@ -899,21 +899,27 @@ func (r *Repository) Search(at vcs.CommitID, opt vcs.SearchOptions) ([]*vcs.Sear
 	return res, err
 }
 
-func (r *Repository) Committers() ([]*vcs.Committer, error) {
+func (r *Repository) Committers(opt vcs.CommittersOptions) ([]*vcs.Committer, error) {
 	r.editLock.RLock()
 	defer r.editLock.RUnlock()
 
-	cmd := exec.Command("git", "shortlog", "-sne")
+	if opt.Rev == "" {
+		opt.Rev = "HEAD"
+	}
+
+	cmd := exec.Command("git", "shortlog", "-sne", opt.Rev)
 	cmd.Dir = r.Dir
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return nil, fmt.Errorf("exec `git shortlog -sne` failed: %v. Output was:\n\n%s", err, string(out))
 	}
-	log.Printf("command output: %v", string(out))
 	out = bytes.TrimSpace(out)
 
 	allEntries := bytes.Split(out, []byte{'\n'})
 	numEntries := len(allEntries)
+	if opt.N > 0 && numEntries > opt.N {
+		numEntries = opt.N
+	}
 	var committers []*vcs.Committer
 	for i := 0; i < numEntries; i++ {
 		line := string(allEntries[i])

--- a/vcs/hgcmd/repo.go
+++ b/vcs/hgcmd/repo.go
@@ -420,6 +420,10 @@ func (r *Repository) BlameFile(path string, opt *vcs.BlameOptions) ([]*vcs.Hunk,
 	return hunks, nil
 }
 
+func (r *Repository) Committers() ([]*vcs.Committer, error) {
+	return nil, fmt.Errorf("Committers() not implemented for vcs type: hg")
+}
+
 func (r *Repository) FileSystem(at vcs.CommitID) (vfs.FileSystem, error) {
 	return &hgFSCmd{
 		dir: r.Dir,

--- a/vcs/hgcmd/repo.go
+++ b/vcs/hgcmd/repo.go
@@ -420,7 +420,7 @@ func (r *Repository) BlameFile(path string, opt *vcs.BlameOptions) ([]*vcs.Hunk,
 	return hunks, nil
 }
 
-func (r *Repository) Committers() ([]*vcs.Committer, error) {
+func (r *Repository) Committers(opt vcs.CommittersOptions) ([]*vcs.Committer, error) {
 	return nil, fmt.Errorf("Committers() not implemented for vcs type: hg")
 }
 

--- a/vcs/repository.go
+++ b/vcs/repository.go
@@ -138,7 +138,7 @@ type CommitsOptions struct {
 type CommittersOptions struct {
 	N int // limit the number of returned committers, ordered by decreasing number of commits (0 means no limit)
 
-	Rev string // the rev for which committer stats will be fetched ("" means HEAD)
+	Rev string // the rev for which committer stats will be fetched ("" means use the current revision)
 }
 
 // DiffOptions configures a diff.

--- a/vcs/repository.go
+++ b/vcs/repository.go
@@ -44,6 +44,9 @@ type Repository interface {
 	// as this can be expensive for large branches.
 	Commits(CommitsOptions) (commits []*Commit, total uint, err error)
 
+	// Committers returns the per-author commit statistics of the repo.
+	Committers() ([]*Committer, error)
+
 	// FileSystem opens the repository file tree at a given commit ID.
 	//
 	// Implementations may choose to check that the commit exists

--- a/vcs/repository.go
+++ b/vcs/repository.go
@@ -45,7 +45,7 @@ type Repository interface {
 	Commits(CommitsOptions) (commits []*Commit, total uint, err error)
 
 	// Committers returns the per-author commit statistics of the repo.
-	Committers() ([]*Committer, error)
+	Committers(CommittersOptions) ([]*Committer, error)
 
 	// FileSystem opens the repository file tree at a given commit ID.
 	//
@@ -131,6 +131,14 @@ type CommitsOptions struct {
 	Path string // only commits modifying the given path are selected (optional)
 
 	NoTotal bool // avoid counting the total number of commits
+}
+
+// CommittersOptions specifies limits on the list of committers returned by
+// (Repository).Committers.
+type CommittersOptions struct {
+	N int // limit the number of returned committers, ordered by decreasing number of commits (0 means no limit)
+
+	Rev string // the rev for which committer stats will be fetched ("" means HEAD)
 }
 
 // DiffOptions configures a diff.

--- a/vcs/testing/mock_repository.go
+++ b/vcs/testing/mock_repository.go
@@ -26,7 +26,7 @@ type MockRepository struct {
 	MergeBase_          func(a, b vcs.CommitID) (vcs.CommitID, error)
 	CrossRepoMergeBase_ func(a vcs.CommitID, repoB vcs.Repository, b vcs.CommitID) (vcs.CommitID, error)
 
-	Committers_ func() ([]*vcs.Committer, error)
+	Committers_ func(opt vcs.CommittersOptions) ([]*vcs.Committer, error)
 }
 
 var (
@@ -88,6 +88,6 @@ func (r MockRepository) CrossRepoMergeBase(a vcs.CommitID, repoB vcs.Repository,
 	return r.CrossRepoMergeBase_(a, repoB, b)
 }
 
-func (r MockRepository) Committers() ([]*vcs.Committer, error) {
-	return r.Committers_()
+func (r MockRepository) Committers(opt vcs.CommittersOptions) ([]*vcs.Committer, error) {
+	return r.Committers_(opt)
 }

--- a/vcs/testing/mock_repository.go
+++ b/vcs/testing/mock_repository.go
@@ -25,6 +25,8 @@ type MockRepository struct {
 
 	MergeBase_          func(a, b vcs.CommitID) (vcs.CommitID, error)
 	CrossRepoMergeBase_ func(a vcs.CommitID, repoB vcs.Repository, b vcs.CommitID) (vcs.CommitID, error)
+
+	Committers_ func() ([]*vcs.Committer, error)
 }
 
 var (
@@ -84,4 +86,8 @@ func (r MockRepository) MergeBase(a, b vcs.CommitID) (vcs.CommitID, error) {
 
 func (r MockRepository) CrossRepoMergeBase(a vcs.CommitID, repoB vcs.Repository, b vcs.CommitID) (vcs.CommitID, error) {
 	return r.CrossRepoMergeBase_(a, repoB, b)
+}
+
+func (r MockRepository) Committers() ([]*vcs.Committer, error) {
+	return r.Committers_()
 }

--- a/vcs/vcs.pb.go
+++ b/vcs/vcs.pb.go
@@ -17,6 +17,7 @@ It has these top-level messages:
 	Tag
 	SearchOptions
 	SearchResult
+	Committer
 */
 package vcs
 
@@ -181,6 +182,17 @@ type SearchResult struct {
 func (m *SearchResult) Reset()         { *m = SearchResult{} }
 func (m *SearchResult) String() string { return proto.CompactTextString(m) }
 func (*SearchResult) ProtoMessage()    {}
+
+// A Committer is a contributor to a repository.
+type Committer struct {
+	Name    string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Email   string `protobuf:"bytes,2,opt,name=email,proto3" json:"email,omitempty"`
+	Commits int32  `protobuf:"varint,3,opt,name=commits,proto3" json:"commits,omitempty"`
+}
+
+func (m *Committer) Reset()         { *m = Committer{} }
+func (m *Committer) String() string { return proto.CompactTextString(m) }
+func (*Committer) ProtoMessage()    {}
 
 func init() {
 }

--- a/vcs/vcs.proto
+++ b/vcs/vcs.proto
@@ -108,3 +108,10 @@ message SearchResult {
 	// EndByte).
 	bytes match = 6;
 }
+
+// A Committer is a contributor to a repository.
+message Committer {
+	string name = 1;
+	string email = 2;
+	int32 commits = 3;
+}


### PR DESCRIPTION
Added method Repository.Committers() to fetch the committers list in a git repo using `git shortlog -sne {rev}` command. The information returned for each committer consists of: name, email, # of commits in the specified branch/revision.

This method is only implemented for `gitcmd`; a mercurial implementation is pending.