### PR TITLE
Add HTTPSConfig to RemoteOpts, ability to provide password.

### DIFF
--- a/vcs/gitcmd/repo.go
+++ b/vcs/gitcmd/repo.go
@@ -94,7 +94,7 @@ func Clone(url, dir string, opt vcs.CloneOpt) (*Repository, error) {
 
 	if opt.HTTPS != nil {
 		env := environ(os.Environ())
-		env.unset("GIT_TERMINAL_PROMPT")
+		env.Unset("GIT_TERMINAL_PROMPT")
 
 		gitPassHelper, err := makeGitPassHelper(opt.HTTPS.Pass)
 		if err != nil {
@@ -630,7 +630,7 @@ func (r *Repository) UpdateEverything(opt vcs.RemoteOpts) error {
 
 	if opt.HTTPS != nil {
 		env := environ(os.Environ())
-		env.unset("GIT_TERMINAL_PROMPT")
+		env.Unset("GIT_TERMINAL_PROMPT")
 
 		gitPassHelper, err := makeGitPassHelper(opt.HTTPS.Pass)
 		if err != nil {
@@ -1255,8 +1255,8 @@ var InsecureSkipCheckVerifySSH bool
 // environ is a slice of strings representing the environment, in the form "key=value".
 type environ []string
 
-// unset unsets a single environment variable.
-func (e *environ) unset(key string) {
+// Unset a single environment variable.
+func (e *environ) Unset(key string) {
 	for i := range *e {
 		if strings.HasPrefix((*e)[i], key+"=") {
 			(*e)[i] = (*e)[len(*e)-1]

--- a/vcs/gitcmd/repo.go
+++ b/vcs/gitcmd/repo.go
@@ -92,6 +92,20 @@ func Clone(url, dir string, opt vcs.CloneOpt) (*Repository, error) {
 		cmd.Env = []string{"GIT_SSH=" + gitSSHWrapper}
 	}
 
+	if opt.HTTPS != nil {
+		env := environ(os.Environ())
+		env.unset("GIT_TERMINAL_PROMPT")
+
+		gitPassHelper, err := makeGitPassHelper(opt.HTTPS.Pass)
+		if err != nil {
+			return nil, err
+		}
+		defer os.Remove(gitPassHelper)
+		env = append(env, "GIT_ASKPASS="+gitPassHelper)
+
+		cmd.Env = env
+	}
+
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return nil, fmt.Errorf("exec `git clone` failed: %s. Output was:\n\n%s", err, out)
@@ -612,6 +626,20 @@ func (r *Repository) UpdateEverything(opt vcs.RemoteOpts) error {
 		}
 		defer os.Remove(gitSSHWrapper)
 		cmd.Env = []string{"GIT_SSH=" + gitSSHWrapper}
+	}
+
+	if opt.HTTPS != nil {
+		env := environ(os.Environ())
+		env.unset("GIT_TERMINAL_PROMPT")
+
+		gitPassHelper, err := makeGitPassHelper(opt.HTTPS.Pass)
+		if err != nil {
+			return err
+		}
+		defer os.Remove(gitPassHelper)
+		env = append(env, "GIT_ASKPASS="+gitPassHelper)
+
+		cmd.Env = env
 	}
 
 	out, err := cmd.CombinedOutput()
@@ -1195,8 +1223,45 @@ func makeGitSSHWrapper(privKey []byte) (sshWrapper, keyFile string, err error) {
 	return tmpFile, keyFile, nil
 }
 
+// makeGitPassHelper writes a GIT_ASKPASS helper that supplies password over stdout.
+// You should remove the passHelper after using it.
+func makeGitPassHelper(pass string) (passHelper string, err error) {
+	f, err := ioutil.TempFile("", "go-vcs-gitcmd-ask")
+	if err != nil {
+		return "", err
+	}
+	tmpFile := f.Name()
+	if err := f.Chmod(0500); err != nil {
+		os.Remove(tmpFile)
+		return "", err
+	}
+	if _, err := f.WriteString("#!/bin/sh\necho '" + pass + "'\n"); err != nil {
+		os.Remove(tmpFile)
+		return "", err
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(tmpFile)
+		return "", err
+	}
+	return tmpFile, nil
+}
+
 // InsecureSkipCheckVerifySSH controls whether the client verifies the
 // SSH server's certificate or host key. If InsecureSkipCheckVerifySSH
 // is true, the program is susceptible to a man-in-the-middle
 // attack. This should only be used for testing.
 var InsecureSkipCheckVerifySSH bool
+
+// environ is a slice of strings representing the environment, in the form "key=value".
+type environ []string
+
+// unset unsets a single environment variable.
+func (e *environ) unset(key string) {
+	for i := range *e {
+		if strings.HasPrefix((*e)[i], key+"=") {
+			(*e)[i] = (*e)[len(*e)-1]
+			*e = (*e)[:len(*e)-1]
+			break
+		}
+	}
+}

--- a/vcs/remote.go
+++ b/vcs/remote.go
@@ -3,12 +3,19 @@ package vcs
 // RemoteOpts configures interactions with a remote repository.
 type RemoteOpts struct {
 	SSH *SSHConfig // ssh configuration for communication with the remote
+
+	HTTPS *HTTPSConfig // Optional HTTPS configuration for communication with the remote.
 }
 
 type SSHConfig struct {
 	User       string `json:",omitempty"` // ssh user (if empty, inferred from URL)
 	PublicKey  []byte `json:",omitempty"` // ssh public key (if nil, inferred from PrivateKey)
 	PrivateKey []byte // ssh private key, usually passed to ssh.ParsePrivateKey (passphrases currently unsupported)
+}
+
+// HTTPSConfig configures HTTPS for communication with remotes.
+type HTTPSConfig struct {
+	Pass string // Pass is the password provided to the vcs.
 }
 
 // A RemoteUpdater is a repository that can fetch updates to itself


### PR DESCRIPTION
Use a git pass helper via `GIT_ASKPASS` env var (https://www.kernel.org/pub/software/scm/git/docs/gitcredentials.html) to provide password to git commands.