### PR TITLE
Windows support 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: go
 
 go:
-  - 1.2
-  - 1.3
   - 1.4
+  - 1.5
   - tip
 
 matrix:

--- a/vcs/diff_test.go
+++ b/vcs/diff_test.go
@@ -2,6 +2,7 @@ package vcs_test
 
 import (
 	"reflect"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -97,6 +98,9 @@ func TestRepository_Diff(t *testing.T) {
 		// wantDiff field doc for more info.
 		test.wantDiff.Raw = strings.Replace(test.wantDiff.Raw, "%(baseCommitID)", string(baseCommitID), -1)
 		test.wantDiff.Raw = strings.Replace(test.wantDiff.Raw, "%(headCommitID)", string(headCommitID), -1)
+		if runtime.GOOS == "windows" {
+			test.wantDiff.Raw = strings.Replace(test.wantDiff.Raw, "/dev/null", `\dev\null`, -1)
+		}
 
 		if !reflect.DeepEqual(diff, test.wantDiff) {
 			t.Errorf("%s: diff != wantDiff\n\ndiff ==========\n%s\n\nwantDiff ==========\n%s", label, asJSON(diff), asJSON(test.wantDiff))
@@ -204,6 +208,9 @@ func TestRepository_Diff_rename(t *testing.T) {
 		// wantDiff field doc for more info.
 		test.wantDiff.Raw = strings.Replace(test.wantDiff.Raw, "%(baseCommitID)", string(baseCommitID), -1)
 		test.wantDiff.Raw = strings.Replace(test.wantDiff.Raw, "%(headCommitID)", string(headCommitID), -1)
+		if runtime.GOOS == "windows" {
+			test.wantDiff.Raw = strings.Replace(test.wantDiff.Raw, "/dev/null", `\dev\null`, -1)
+		}
 
 		if !reflect.DeepEqual(diff, test.wantDiff) {
 			t.Errorf("%s: diff != wantDiff\n\ndiff ==========\n%s\n\nwantDiff ==========\n%s", label, asJSON(diff), asJSON(test.wantDiff))

--- a/vcs/gitcmd/repo.go
+++ b/vcs/gitcmd/repo.go
@@ -1269,7 +1269,7 @@ func makeGitSSHWrapper(privKey []byte) (sshWrapper, keyFile string, err error) {
 		return "", keyFile, err
 	}
 
-	tmpFile, err := gitSshWrapper(keyFile, otherOpt)
+	tmpFile, err := gitSSHWrapper(keyFile, otherOpt)
 	return tmpFile, keyFile, err
 }
 
@@ -1315,7 +1315,7 @@ func (e *environ) Unset(key string) {
 }
 
 // Makes system-dependend SSH wrapper
-func gitSshWrapper(keyFile string, otherOpt string) (string, error) {
+func gitSSHWrapper(keyFile string, otherOpt string) (string, error) {
 	// TODO(sqs): encrypt and store the key in the env so that
 	// attackers can't decrypt if they have disk access after our
 	// process dies
@@ -1325,9 +1325,8 @@ func gitSshWrapper(keyFile string, otherOpt string) (string, error) {
 	if runtime.GOOS == "windows" {
 		script = `
 	@echo off
-	ssh "%@"
+	ssh -o ControlMaster=no -o ControlPath=none ` + otherOpt + ` -i ` + filepath.ToSlash(keyFile) + ` "%@"
 `
-		//	ssh -o ControlMaster=no -o ControlPath=none ` + otherOpt + ` -i ` + filepath.ToSlash(keyFile) + ` "%@"
 	} else {
 		script = `
 	#!/bin/sh

--- a/vcs/gitcmd/repo.go
+++ b/vcs/gitcmd/repo.go
@@ -1240,7 +1240,7 @@ func makeGitSSHWrapper(privKey []byte) (sshWrapper, keyFile string, err error) {
 		return "", "", err
 	}
 	keyFile = kf.Name()
-	err = ioutil.WriteFile(keyFile, privKey, 0600)
+	err = internal.WriteFileWithPermissions(keyFile, privKey, 0600)
 	if err != nil {
 		return "", keyFile, err
 	}
@@ -1266,7 +1266,7 @@ func makeGitPassHelper(pass string) (passHelper string, err error) {
 		script = "#!/bin/sh\necho '" + pass + "'\n"
 	}
 
-	err = ioutil.WriteFile(tmpFile, []byte(script), 0500)
+	err = internal.WriteFileWithPermissions(tmpFile, []byte(script), 0500)
 	return tmpFile, err
 }
 
@@ -1315,6 +1315,6 @@ func gitSshWrapper(keyFile string, otherOpt string) (string, error) {
 		return "", err
 	}
 
-	err = ioutil.WriteFile(sshWrapperName, []byte(script), 0500)
+	err = internal.WriteFileWithPermissions(sshWrapperName, []byte(script), 0500)
 	return sshWrapperName, err
 }

--- a/vcs/gitcmd/repo.go
+++ b/vcs/gitcmd/repo.go
@@ -1299,16 +1299,17 @@ func gitSshWrapper(keyFile string, otherOpt string) (string, error) {
 	var script string
 
 	if runtime.GOOS == "windows" {
-	script = `
+		script = `
 	@echo off
 	ssh "%@"
-`	
-//	ssh -o ControlMaster=no -o ControlPath=none ` + otherOpt + ` -i ` + filepath.ToSlash(keyFile) + ` "%@"
-} else {
-	script = `
+`
+		//	ssh -o ControlMaster=no -o ControlPath=none ` + otherOpt + ` -i ` + filepath.ToSlash(keyFile) + ` "%@"
+	} else {
+		script = `
 	#!/bin/sh
 	exec /usr/bin/ssh -o ControlMaster=no -o ControlPath=none ` + otherOpt + ` -i ` + filepath.ToSlash(keyFile) + ` "$@"
-`	}
+`
+	}
 
 	sshWrapperName, err := internal.ScriptFile("go-vcs-gitcmd")
 	if err != nil {

--- a/vcs/gitcmd/repo.go
+++ b/vcs/gitcmd/repo.go
@@ -89,7 +89,7 @@ func Clone(url, dir string, opt vcs.CloneOpt) (*Repository, error) {
 	cmd := exec.Command("git", args...)
 
 	if opt.SSH != nil {
-		gitSSHWrapper, keyFile, err := makeGitSSHWrapper(opt.SSH.PrivateKey)
+		gitSSHWrapper, gitSSHWrapperDir, keyFile, err := makeGitSSHWrapper(opt.SSH.PrivateKey)
 		defer func() {
 			if keyFile != "" {
 				if err := os.Remove(keyFile); err != nil {
@@ -101,6 +101,9 @@ func Clone(url, dir string, opt vcs.CloneOpt) (*Repository, error) {
 			return nil, err
 		}
 		defer os.Remove(gitSSHWrapper)
+		if gitSSHWrapperDir != "" {
+			defer os.RemoveAll(gitSSHWrapperDir)
+		}
 		cmd.Env = []string{"GIT_SSH=" + gitSSHWrapper}
 	}
 
@@ -108,11 +111,14 @@ func Clone(url, dir string, opt vcs.CloneOpt) (*Repository, error) {
 		env := environ(os.Environ())
 		env.Unset("GIT_TERMINAL_PROMPT")
 
-		gitPassHelper, err := makeGitPassHelper(opt.HTTPS.Pass)
+		gitPassHelper, gitPassHelperDir, err := makeGitPassHelper(opt.HTTPS.Pass)
 		if err != nil {
 			return nil, err
 		}
 		defer os.Remove(gitPassHelper)
+		if gitPassHelperDir != "" {
+			defer os.RemoveAll(gitPassHelperDir)
+		}
 		env = append(env, "GIT_ASKPASS="+gitPassHelper)
 
 		cmd.Env = env
@@ -625,7 +631,7 @@ func (r *Repository) UpdateEverything(opt vcs.RemoteOpts) error {
 	cmd.Dir = r.Dir
 
 	if opt.SSH != nil {
-		gitSSHWrapper, keyFile, err := makeGitSSHWrapper(opt.SSH.PrivateKey)
+		gitSSHWrapper, gitSSHWrapperDir, keyFile, err := makeGitSSHWrapper(opt.SSH.PrivateKey)
 		defer func() {
 			if keyFile != "" {
 				if err := os.Remove(keyFile); err != nil {
@@ -637,6 +643,9 @@ func (r *Repository) UpdateEverything(opt vcs.RemoteOpts) error {
 			return err
 		}
 		defer os.Remove(gitSSHWrapper)
+		if gitSSHWrapperDir != "" {
+			defer os.RemoveAll(gitSSHWrapperDir)
+		}
 		cmd.Env = []string{"GIT_SSH=" + gitSSHWrapper}
 	}
 
@@ -644,11 +653,14 @@ func (r *Repository) UpdateEverything(opt vcs.RemoteOpts) error {
 		env := environ(os.Environ())
 		env.Unset("GIT_TERMINAL_PROMPT")
 
-		gitPassHelper, err := makeGitPassHelper(opt.HTTPS.Pass)
+		gitPassHelper, gitPassHelperDir, err := makeGitPassHelper(opt.HTTPS.Pass)
 		if err != nil {
 			return err
 		}
 		defer os.Remove(gitPassHelper)
+		if gitPassHelperDir != "" {
+			defer os.RemoveAll(gitPassHelperDir)
+		}
 		env = append(env, "GIT_ASKPASS="+gitPassHelper)
 
 		cmd.Env = env
@@ -1251,9 +1263,9 @@ func (fs *gitFSCmd) String() string {
 }
 
 // makeGitSSHWrapper writes a GIT_SSH wrapper that runs ssh with the
-// private key. You should close and remove the sshWrapper and remove
+// private key. You should remove the sshWrapper, sshWrapperDir and
 // the keyFile after using them.
-func makeGitSSHWrapper(privKey []byte) (sshWrapper, keyFile string, err error) {
+func makeGitSSHWrapper(privKey []byte) (sshWrapper, sshWrapperDir, keyFile string, err error) {
 	var otherOpt string
 	if InsecureSkipCheckVerifySSH {
 		otherOpt = "-o StrictHostKeyChecking=no"
@@ -1261,25 +1273,25 @@ func makeGitSSHWrapper(privKey []byte) (sshWrapper, keyFile string, err error) {
 
 	kf, err := ioutil.TempFile("", "go-vcs-gitcmd-key")
 	if err != nil {
-		return "", "", err
+		return "", "", "", err
 	}
 	keyFile = kf.Name()
 	err = internal.WriteFileWithPermissions(keyFile, privKey, 0600)
 	if err != nil {
-		return "", keyFile, err
+		return "", "", keyFile, err
 	}
 
-	tmpFile, err := gitSSHWrapper(keyFile, otherOpt)
-	return tmpFile, keyFile, err
+	tmpFile, tmpFileDir, err := gitSSHWrapper(keyFile, otherOpt)
+	return tmpFile, tmpFileDir, keyFile, err
 }
 
 // makeGitPassHelper writes a GIT_ASKPASS helper that supplies password over stdout.
-// You should remove the passHelper after using it.
-func makeGitPassHelper(pass string) (passHelper string, err error) {
+// You should remove the passHelper (and tempDir if any) after using it.
+func makeGitPassHelper(pass string) (passHelper string, tempDir string, err error) {
 
-	tmpFile, err := internal.ScriptFile("go-vcs-gitcmd-ask")
+	tmpFile, dir, err := internal.ScriptFile("go-vcs-gitcmd-ask")
 	if err != nil {
-		return "", err
+		return tmpFile, dir, err
 	}
 
 	var script string
@@ -1291,7 +1303,7 @@ func makeGitPassHelper(pass string) (passHelper string, err error) {
 	}
 
 	err = internal.WriteFileWithPermissions(tmpFile, []byte(script), 0500)
-	return tmpFile, err
+	return tmpFile, dir, err
 }
 
 // InsecureSkipCheckVerifySSH controls whether the client verifies the
@@ -1315,7 +1327,7 @@ func (e *environ) Unset(key string) {
 }
 
 // Makes system-dependent SSH wrapper
-func gitSSHWrapper(keyFile string, otherOpt string) (string, error) {
+func gitSSHWrapper(keyFile string, otherOpt string) (sshWrapperFile string, tempDir string, err error) {
 	// TODO(sqs): encrypt and store the key in the env so that
 	// attackers can't decrypt if they have disk access after our
 	// process dies
@@ -1334,11 +1346,11 @@ func gitSSHWrapper(keyFile string, otherOpt string) (string, error) {
 `
 	}
 
-	sshWrapperName, err := internal.ScriptFile("go-vcs-gitcmd")
+	sshWrapperName, tempDir, err := internal.ScriptFile("go-vcs-gitcmd")
 	if err != nil {
-		return "", err
+		return sshWrapperName, tempDir, err
 	}
 
 	err = internal.WriteFileWithPermissions(sshWrapperName, []byte(script), 0500)
-	return sshWrapperName, err
+	return sshWrapperName, tempDir, err
 }

--- a/vcs/gitcmd/repo.go
+++ b/vcs/gitcmd/repo.go
@@ -1314,7 +1314,7 @@ func (e *environ) Unset(key string) {
 	}
 }
 
-// Makes system-dependend SSH wrapper
+// Makes system-dependent SSH wrapper
 func gitSSHWrapper(keyFile string, otherOpt string) (string, error) {
 	// TODO(sqs): encrypt and store the key in the env so that
 	// attackers can't decrypt if they have disk access after our

--- a/vcs/hg/repo.go
+++ b/vcs/hg/repo.go
@@ -300,6 +300,7 @@ func (fs *hgFSNative) getManifest(chgId hg_revlog.FileRevSpec) (m hg_store.Manif
 }
 
 func (fs *hgFSNative) getEntry(path string) (*hg_revlog.Rec, *hg_store.ManifestEnt, error) {
+	path = filepath.ToSlash(path)
 	fileLog, err := fs.st.OpenRevlog(path)
 	if err != nil {
 		return nil, nil, err

--- a/vcs/hgcmd/repo.go
+++ b/vcs/hgcmd/repo.go
@@ -67,6 +67,10 @@ type Repository struct {
 	Dir string
 }
 
+func (r *Repository) RepoDir() string {
+	return r.Dir
+}
+
 func (r *Repository) ResolveRevision(spec string) (vcs.CommitID, error) {
 	cmd := exec.Command("hg", "identify", "--debug", "-i", "--rev="+spec)
 	cmd.Dir = r.Dir

--- a/vcs/internal/script.go
+++ b/vcs/internal/script.go
@@ -2,52 +2,44 @@ package internal
 
 import (
 	"io/ioutil"
-	"math/rand"
 	"os"
 	"path/filepath"
 	"runtime"
-	"strconv"
-	"time"
 )
-
-var gen rand.Source
-
-func init() {
-	gen = rand.NewSource(time.Now().UnixNano())
-}
 
 // Constructs platform-specific temporary script file with a given prefix
 // On Windows such a file must have .bat extension
-func ScriptFile(prefix string) (string, error) {
+// Returns triplet where
+// - filePath is a location of file
+// - rootPath may refer to temporary root directory
+// (everything under the rootPath (including rootPath) should be removed when no longer needed)
+// rootPath makes sense on Windows only where location of script file is TEMP_DIR()/RANDOM_DIR()/FILE.bat
+// - error indicates possible error
+func ScriptFile(prefix string) (filePath string, rootPath string, err error) {
 
 	if runtime.GOOS == "windows" {
-		for {
-			tempFile := filepath.Join(os.TempDir(), prefix+strconv.FormatInt(gen.Int63(), 36)+".bat")
-			_, err := os.Stat(tempFile)
-			if err != nil {
-				if os.IsNotExist(err) {
-					return filepath.ToSlash(tempFile), nil
-				} else {
-					return "", err
-				}
-			}
+		// making unique temporary directory and file inside it
+		tempDir, err := ioutil.TempDir("", prefix)
+		if err != nil {
+			return "", "", err
 		}
+		return filepath.Join(tempDir, prefix+".bat"), tempDir, nil
 	} else {
 		tf, err := ioutil.TempFile("", prefix)
 		if err != nil {
-			return "", err
+			return "", "", err
 		}
 		tf.Close()
-		return filepath.ToSlash(tf.Name()), nil
+		return filepath.ToSlash(tf.Name()), "", nil
 	}
 }
 
 // Wrapper around ioutil.WriteFile that updates permissions regardless if file existed before
 func WriteFileWithPermissions(file string, content []byte, perm os.FileMode) error {
 	err := ioutil.WriteFile(file, content, perm)
-   	if err != nil {
-   		return err
-   	}
-   	// ioutil.WriteFile applies permissions only for files that weren't exist
+	if err != nil {
+		return err
+	}
+	// ioutil.WriteFile applies permissions only for files that weren't exist
 	return os.Chmod(file, perm)
 }

--- a/vcs/internal/script.go
+++ b/vcs/internal/script.go
@@ -33,10 +33,25 @@ func ScriptFile(prefix string) (string, error) {
         	}
     	}
 	} else {
-		tf, err := ioutil.TempFile("", "go-vcs-gitcmd")
+		tf, err := ioutil.TempFile("", prefix)
 		if err != nil {
 			return "", err
 		}
+		tf.Close()
 		return filepath.ToSlash(tf.Name()), nil
 	}
+}
+
+// Wrapper around ioutil.WriteFile that updates permissions regardless if file existed before
+func WriteFileWithPermissions(file string, content []byte, perm os.FileMode) error {
+	fi, err := os.OpenFile(file, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, perm)
+	if err != nil {
+		return err
+	}
+	_,err = fi.Write(content)
+	if err != nil {
+		return err
+	}
+	fi.Close()
+	return os.Chmod(file, perm)
 }

--- a/vcs/internal/script.go
+++ b/vcs/internal/script.go
@@ -1,0 +1,42 @@
+package internal
+
+import (
+	"path/filepath"
+	"io/ioutil"
+	"math/rand"
+	"os"
+	"runtime"
+	"strconv"
+	"time"
+)
+
+var gen rand.Source
+
+func init() {
+	gen = rand.NewSource(time.Now().UnixNano())
+}
+
+// Constructs platform-specific temporary script file with a given prefix
+// On Windows such a file must have .bat extension
+func ScriptFile(prefix string) (string, error) {
+	
+	if runtime.GOOS == "windows" {
+		for {
+        	tempFile := filepath.Join(os.TempDir(), prefix + strconv.FormatInt(gen.Int63(), 36) + ".bat")
+        	_, err := os.Stat(tempFile)
+        	if err != nil {
+        		if os.IsNotExist(err) {
+        			return filepath.ToSlash(tempFile), nil
+        		} else {
+        			return "", err
+        		}
+        	}
+    	}
+	} else {
+		tf, err := ioutil.TempFile("", "go-vcs-gitcmd")
+		if err != nil {
+			return "", err
+		}
+		return filepath.ToSlash(tf.Name()), nil
+	}
+}

--- a/vcs/internal/script.go
+++ b/vcs/internal/script.go
@@ -1,10 +1,10 @@
 package internal
 
 import (
-	"path/filepath"
 	"io/ioutil"
 	"math/rand"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strconv"
 	"time"
@@ -19,19 +19,19 @@ func init() {
 // Constructs platform-specific temporary script file with a given prefix
 // On Windows such a file must have .bat extension
 func ScriptFile(prefix string) (string, error) {
-	
+
 	if runtime.GOOS == "windows" {
 		for {
-        	tempFile := filepath.Join(os.TempDir(), prefix + strconv.FormatInt(gen.Int63(), 36) + ".bat")
-        	_, err := os.Stat(tempFile)
-        	if err != nil {
-        		if os.IsNotExist(err) {
-        			return filepath.ToSlash(tempFile), nil
-        		} else {
-        			return "", err
-        		}
-        	}
-    	}
+			tempFile := filepath.Join(os.TempDir(), prefix+strconv.FormatInt(gen.Int63(), 36)+".bat")
+			_, err := os.Stat(tempFile)
+			if err != nil {
+				if os.IsNotExist(err) {
+					return filepath.ToSlash(tempFile), nil
+				} else {
+					return "", err
+				}
+			}
+		}
 	} else {
 		tf, err := ioutil.TempFile("", prefix)
 		if err != nil {
@@ -44,14 +44,10 @@ func ScriptFile(prefix string) (string, error) {
 
 // Wrapper around ioutil.WriteFile that updates permissions regardless if file existed before
 func WriteFileWithPermissions(file string, content []byte, perm os.FileMode) error {
-	fi, err := os.OpenFile(file, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, perm)
-	if err != nil {
-		return err
-	}
-	_,err = fi.Write(content)
-	if err != nil {
-		return err
-	}
-	fi.Close()
+	err := ioutil.WriteFile(file, content, perm)
+   	if err != nil {
+   		return err
+   	}
+   	// ioutil.WriteFile applies permissions only for files that weren't exist
 	return os.Chmod(file, perm)
 }

--- a/vcs/repository_test.go
+++ b/vcs/repository_test.go
@@ -1819,6 +1819,14 @@ func appleTime(t string) string {
 }
 
 // Computes hash of last commit in a given repo dir
+// On Windows, content of a "link file" differs based on the tool that produced it.
+// For example:
+// - Cygwin may create four different link types, see https://cygwin.com/cygwin-ug-net/using.html#pathnames-symlinks,
+// - MSYS's ln copies target file
+// Such behavior makes impossible precalculation of SHA hashes to be used in TestRepository_FileSystem_Symlinks
+// because for example Git for Windows (http://git-scm.com) is not aware of symlinks and computes link file's SHA which
+// may differ from original file content's SHA.
+// As a temporary workaround, we calculating SHA hash by asking git/hg to compute it
 func computeCommitHash(repoDir string, git bool) string {
 	buf := &bytes.Buffer{}
 

--- a/vcs/repository_test.go
+++ b/vcs/repository_test.go
@@ -1176,7 +1176,7 @@ func TestRepository_FileSystem_Symlinks(t *testing.T) {
 			continue
 		}
 		if runtime.GOOS != "windows" {
-			// TODO(alexsaveliev) make it work
+			// TODO(alexsaveliev) make it work on Windows too
 			checkSymlinkFileInfo(label+" (Lstat)", link1Linfo)
 		}
 
@@ -1192,7 +1192,7 @@ func TestRepository_FileSystem_Symlinks(t *testing.T) {
 			continue
 		}
 		if runtime.GOOS != "windows" {
-			// TODO(alexsaveliev) make it work
+			// TODO(alexsaveliev) make it work on Windows too
 			checkSymlinkFileInfo(label+" (ReadDir)", entries[1])
 		}
 

--- a/vcs/repository_test.go
+++ b/vcs/repository_test.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -1403,7 +1404,7 @@ func TestRepository_FileSystem_gitSubmodules(t *testing.T) {
 	const submodCommit = "94aa9078934ce2776ccbb589569eca5ef575f12e"
 
 	gitCommands := []string{
-		"git submodule add " + submodDir + " submod",
+		"git submodule add " + filepath.ToSlash(submodDir) + " submod",
 		"GIT_COMMITTER_NAME=a GIT_COMMITTER_EMAIL=a@a.com GIT_COMMITTER_DATE=2006-01-02T15:04:05Z git commit -m 'add submodule' --author='a <a@a.com>' --date 2006-01-02T15:04:05Z",
 	}
 	tests := map[string]struct {
@@ -1445,7 +1446,7 @@ func TestRepository_FileSystem_gitSubmodules(t *testing.T) {
 			if !ok {
 				t.Errorf("%s: submod.Sys(): got %v, want SubmoduleInfo", label, si)
 			}
-			if want := submodDir; si.URL != want {
+			if want := filepath.ToSlash(submodDir); si.URL != want {
 				t.Errorf("%s: (SubmoduleInfo).URL: got %q, want %q", label, si.URL, want)
 			}
 			if si.CommitID != submodCommit {

--- a/vcs/repository_test.go
+++ b/vcs/repository_test.go
@@ -452,7 +452,7 @@ func TestRepository_Branches_MergedInto(t *testing.T) {
 		"git cmd": {
 			repo: makeGitRepositoryCmd(t, gitCommands...),
 			wantBranches: map[string][]*vcs.Branch{
-				"b1": []*vcs.Branch{
+				"b1": {
 					{Name: "b0", Head: "6520a4539a4cb664537c712216a53d80dd79bbdc"},
 					{Name: "b1", Head: "6520a4539a4cb664537c712216a53d80dd79bbdc"},
 				},
@@ -491,9 +491,9 @@ func TestRepository_Branches_ContainsCommit(t *testing.T) {
 		"git cmd": {
 			repo: makeGitRepositoryCmd(t, gitCommands...),
 			commitToWantBranches: map[string][]*vcs.Branch{
-				"920c0e9d7b287b030ac9770fd7ba3ee9dc1760d9": []*vcs.Branch{{Name: "branch2", Head: "920c0e9d7b287b030ac9770fd7ba3ee9dc1760d9"}},
-				"1224d334dfe08f4693968ea618ad63ae86ec16ca": []*vcs.Branch{{Name: "master", Head: "1224d334dfe08f4693968ea618ad63ae86ec16ca"}},
-				"2816a72df28f699722156e545d038a5203b959de": []*vcs.Branch{{Name: "master", Head: "1224d334dfe08f4693968ea618ad63ae86ec16ca"}, {Name: "branch2", Head: "920c0e9d7b287b030ac9770fd7ba3ee9dc1760d9"}},
+				"920c0e9d7b287b030ac9770fd7ba3ee9dc1760d9": {{Name: "branch2", Head: "920c0e9d7b287b030ac9770fd7ba3ee9dc1760d9"}},
+				"1224d334dfe08f4693968ea618ad63ae86ec16ca": {{Name: "master", Head: "1224d334dfe08f4693968ea618ad63ae86ec16ca"}},
+				"2816a72df28f699722156e545d038a5203b959de": {{Name: "master", Head: "1224d334dfe08f4693968ea618ad63ae86ec16ca"}, {Name: "branch2", Head: "920c0e9d7b287b030ac9770fd7ba3ee9dc1760d9"}},
 			},
 		},
 	}
@@ -1081,16 +1081,16 @@ func TestRepository_FileSystem_Symlinks(t *testing.T) {
 		"hg commit -m commit1 --user 'a <a@a.com>' --date '2006-01-02 15:04:05 UTC'",
 	}
 
- 	var gitCommitID vcs.CommitID
- 	var hgCommitID vcs.CommitID
+	var gitCommitID vcs.CommitID
+	var hgCommitID vcs.CommitID
 
- 	if runtime.GOOS == "windows" {
- 		gitCommitID = ""
- 		hgCommitID = ""
- 	} else {
- 		gitCommitID = "85d3a39020cf28af4b887552fcab9e31a49f2ced"
- 		hgCommitID = "c3fed02bbbc0b58418f32a363b8263aa46b0349e"
- 	}
+	if runtime.GOOS == "windows" {
+		gitCommitID = ""
+		hgCommitID = ""
+	} else {
+		gitCommitID = "85d3a39020cf28af4b887552fcab9e31a49f2ced"
+		hgCommitID = "c3fed02bbbc0b58418f32a363b8263aa46b0349e"
+	}
 
 	tests := map[string]struct {
 		repo interface {
@@ -1100,22 +1100,22 @@ func TestRepository_FileSystem_Symlinks(t *testing.T) {
 		commitID vcs.CommitID
 
 		testFileInfoSys bool // whether to check the SymlinkInfo in FileInfo.Sys()
-		git bool // whether we are working with GIT or HG
+		git             bool // whether we are working with GIT or HG
 	}{
 		// TODO(sqs): implement Lstat and symlink handling for git libgit2, git
 		// cmd, and hg cmd.
 
 		"git libgit2": {
-			repo:     		 makeGitRepositoryLibGit2(t, gitCommands...),
-			commitID: 		 gitCommitID,
+			repo:            makeGitRepositoryLibGit2(t, gitCommands...),
+			commitID:        gitCommitID,
 			testFileInfoSys: true,
-			git:			 true,
+			git:             true,
 		},
 		"git cmd": {
 			repo:            makeGitRepositoryCmd(t, gitCommands...),
 			commitID:        gitCommitID,
 			testFileInfoSys: true,
-			git:			 true,
+			git:             true,
 		},
 		"hg native": {
 			repo:     makeHgRepositoryNative(t, hgCommands...),
@@ -1194,7 +1194,7 @@ func TestRepository_FileSystem_Symlinks(t *testing.T) {
 		if runtime.GOOS != "windows" {
 			// TODO(alexsaveliev) make it work
 			checkSymlinkFileInfo(label+" (ReadDir)", entries[1])
-		}	
+		}
 
 		// link1 stat should follow the link to file1.
 		link1Info, err := fs.Stat("link1")
@@ -1762,21 +1762,21 @@ func computeCommitHash(repoDir string, git bool) string {
 	buf := &bytes.Buffer{}
 
 	if git {
-    	// git cat-file tree "master^{commit}" | git hash-object -t commit --stdin
-    	cat := exec.Command("git", "cat-file", "commit", "master^{commit}")
-    	cat.Dir = repoDir
-        hash := exec.Command("git", "hash-object", "-t", "commit", "--stdin")
-        hash.Stdin, _ = cat.StdoutPipe()
-        hash.Stdout = buf
-        hash.Dir = repoDir
-        _ = hash.Start()
-        _ = cat.Run()
-        _ = hash.Wait()
-    } else {
-    	hash := exec.Command("hg", "--debug", "id", "-i")
-    	hash.Dir = repoDir
-        hash.Stdout = buf
-        _ = hash.Run()
-    }
-    return strings.TrimSpace(buf.String())
+		// git cat-file tree "master^{commit}" | git hash-object -t commit --stdin
+		cat := exec.Command("git", "cat-file", "commit", "master^{commit}")
+		cat.Dir = repoDir
+		hash := exec.Command("git", "hash-object", "-t", "commit", "--stdin")
+		hash.Stdin, _ = cat.StdoutPipe()
+		hash.Stdout = buf
+		hash.Dir = repoDir
+		_ = hash.Start()
+		_ = cat.Run()
+		_ = hash.Wait()
+	} else {
+		hash := exec.Command("hg", "--debug", "id", "-i")
+		hash.Dir = repoDir
+		hash.Stdout = buf
+		_ = hash.Run()
+	}
+	return strings.TrimSpace(buf.String())
 }

--- a/vcs/search_test.go
+++ b/vcs/search_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"sourcegraph.com/sourcegraph/go-vcs/vcs"
+	"sourcegraph.com/sourcegraph/go-vcs/vcs/internal"
 )
 
 func TestRepository_Search_LongLine(t *testing.T) {
@@ -44,7 +45,7 @@ func TestRepository_Search_LongLine(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer os.Remove(tmp.Name())
-	if err := ioutil.WriteFile(tmp.Name(), longline, 0666); err != nil {
+	if err := internal.WriteFileWithPermissions(tmp.Name(), longline, 0666); err != nil {
 		t.Fatal(err)
 	}
 

--- a/vcs/search_test.go
+++ b/vcs/search_test.go
@@ -2,7 +2,9 @@ package vcs_test
 
 import (
 	"bufio"
-	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 
@@ -36,8 +38,18 @@ func TestRepository_Search_LongLine(t *testing.T) {
 		},
 	}
 
+	// alexsaveliev "echo .... > f1" does not work on Windows, let's create test file different way
+	tmp, err := ioutil.TempFile("", "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmp.Name())
+	if err := ioutil.WriteFile(tmp.Name(), longline, 0666); err != nil {
+		t.Fatal(err)
+	}
+
 	gitCommands := []string{
-		fmt.Sprintf("echo %s > f1", string(longline)),
+		"cp " + filepath.ToSlash(tmp.Name()) + " f1",
 		"git add f1",
 		"GIT_COMMITTER_NAME=a GIT_COMMITTER_EMAIL=a@a.com GIT_COMMITTER_DATE=2006-01-02T15:04:05Z git commit f1 -m foo --author='a <a@a.com>' --date 2006-01-02T15:04:05Z",
 	}

--- a/vcs/ssh/server_test.go
+++ b/vcs/ssh/server_test.go
@@ -18,7 +18,7 @@ exit
 		t.Fatal(err)
 	}
 	shell.WriteString(shellScript)
-	if err := shell.Chmod(0700); err != nil {
+	if err := os.Chmod(shell.Name(), 0700); err != nil {
 		t.Fatal(err)
 	}
 	if err := shell.Close(); err != nil {

--- a/vcs/ssh/server_test.go
+++ b/vcs/ssh/server_test.go
@@ -15,7 +15,7 @@ func TestServer(t *testing.T) {
 	var shellScript string
 
 	if runtime.GOOS == "windows" {
-	shellScript = `@echo off
+		shellScript = `@echo off
 	set flag=%1
 	set flag=%flag:"=%
 	set args=%2
@@ -23,12 +23,11 @@ func TestServer(t *testing.T) {
 	echo %flag% %args%
 `
 	} else {
-	shellScript = `#!/bin/sh
+		shellScript = `#!/bin/sh
 echo $*
 exit
 `
 	}
-
 
 	shell, err := internal.ScriptFile("govcs-ssh-shell")
 	if err != nil {

--- a/vcs/ssh/server_test.go
+++ b/vcs/ssh/server_test.go
@@ -3,30 +3,46 @@ package ssh
 import (
 	"io/ioutil"
 	"os"
+	"runtime"
+	"strings"
 	"testing"
 
 	"golang.org/x/crypto/ssh"
+
+	"sourcegraph.com/sourcegraph/go-vcs/vcs/internal"
 )
 
 func TestServer(t *testing.T) {
-	shellScript := `#!/bin/sh
+	var shellScript string
+
+	if runtime.GOOS == "windows" {
+	shellScript = `@echo off
+	set flag=%1
+	set flag=%flag:"=%
+	set args=%2
+	set args=%args:"=%
+	echo %flag% %args%
+`
+	} else {
+	shellScript = `#!/bin/sh
 echo $*
 exit
 `
-	shell, err := ioutil.TempFile("", "govcs-ssh-shell")
+	}
+
+
+	shell, err := internal.ScriptFile("govcs-ssh-shell")
 	if err != nil {
 		t.Fatal(err)
 	}
-	shell.WriteString(shellScript)
-	if err := os.Chmod(shell.Name(), 0700); err != nil {
-		t.Fatal(err)
-	}
-	if err := shell.Close(); err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(shell.Name())
+	defer os.Remove(shell)
 
-	s, err := NewServer(shell.Name(), "/tmp", PrivateKey(SamplePrivKey))
+	err = ioutil.WriteFile(shell, []byte(shellScript), 0700)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s, err := NewServer(shell, os.TempDir(), PrivateKey(SamplePrivKey))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -57,7 +73,7 @@ exit
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got, want := string(out), "-c git-upload-pack 'foo'\n"; got != want {
+	if got, want := strings.TrimSpace(string(out)), "-c git-upload-pack 'foo'"; got != want {
 		t.Errorf("got ssh session output %q, want %q", got, want)
 	}
 }

--- a/vcs/ssh/server_test.go
+++ b/vcs/ssh/server_test.go
@@ -1,7 +1,6 @@
 package ssh
 
 import (
-	"io/ioutil"
 	"os"
 	"runtime"
 	"strings"
@@ -37,7 +36,7 @@ exit
 	}
 	defer os.Remove(shell)
 
-	err = ioutil.WriteFile(shell, []byte(shellScript), 0700)
+	err = internal.WriteFileWithPermissions(shell, []byte(shellScript), 0700)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/vcs/ssh/server_test.go
+++ b/vcs/ssh/server_test.go
@@ -29,11 +29,14 @@ exit
 `
 	}
 
-	shell, err := internal.ScriptFile("govcs-ssh-shell")
+	shell, dir, err := internal.ScriptFile("govcs-ssh-shell")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer os.Remove(shell)
+	if dir != "" {
+		defer os.RemoveAll(dir)
+	}
 
 	err = internal.WriteFileWithPermissions(shell, []byte(shellScript), 0700)
 	if err != nil {


### PR DESCRIPTION
- replaced "git rev-parse SPEC^{commit}" with short-hand "git rev-parse SPEC^0" because {} has a special meaning in Windows
- git client expects path arguments to use slashes, so forcing them
- ssh expects path to key file (-i KEY) to use slashes (checked with Cygwin's git and MSYS's git)
- forcing using slashes instead of OS-specific file separator
- making OS-specific GIT_SSH and GIT_ASKPASS helpers (bat files on Windows vs shell scripts on Unix)
- fixed some unit tests (actually everything but "native git" work now on Windows)
- os.Chmod is platform-independent while os.File.Chmod is not implemented on Windows
- On Windows, commit hash may differ when there are symlinks made by different tool (Cygwin/Msys/...) thus computing proper hash before test (affects unit tests)
- code refactoring: extracted method to write a file and set permissions after
- fixed "native hg" stat() method on Windows


TODO list: 
- is there a easy way to make "native git" compile on Windows?
- enhance TestRepository_FileSystem_Symlinks test on Windows - I made some pieces to execute on Unix/Darwin only