### PR TITLE
Add UpdateResult to UpdateEverything method.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ The goal is to have all supported backends at feature parity, but until then, co
 | vcs.BranchesOptions.BehindAheadBranch | :white_large_square: | :white_check_mark: | :white_large_square: | :white_large_square: |
 | vcs.Repository.Committers             | :white_large_square: | :white_check_mark: | :white_large_square: | :white_large_square: |
 | vcs.FileLister                        | :white_large_square: | :white_check_mark: | :white_large_square: | :white_large_square: |
+| vcs.UpdateResult                      | :white_large_square: | :white_check_mark: | :white_large_square: | :white_large_square: |
 
 Contributions that fill in the gaps are welcome!
 

--- a/cmd/go-vcs/go-vcs.go
+++ b/cmd/go-vcs/go-vcs.go
@@ -108,9 +108,11 @@ func main() {
 		log.Printf("Before remote update, HEAD is %s (from %s ago).", preCommit.ID, preCommit.Author.Date)
 
 		log.Printf("Remote-updating repo in dir %s...", dir)
-		if err := repo.(vcs.RemoteUpdater).UpdateEverything(vcs.RemoteOpts{}); err != nil {
+		result, err := repo.(vcs.RemoteUpdater).UpdateEverything(vcs.RemoteOpts{})
+		if err != nil {
 			log.Fatal(err)
 		}
+		log.Printf("Result is: %+v\n", result)
 
 		postCommit := getHEADCommit()
 		log.Printf("After remote update, HEAD is %s (from %s ago).", postCommit.ID, postCommit.Author.Date)

--- a/vcs/git/clone_update.go
+++ b/vcs/git/clone_update.go
@@ -73,16 +73,16 @@ func Clone(url, dir string, opt vcs.CloneOpt) (vcs.Repository, error) {
 	return r, nil
 }
 
-func (r *Repository) UpdateEverything(opt vcs.RemoteOpts) (vcs.UpdateResult, error) {
+func (r *Repository) UpdateEverything(opt vcs.RemoteOpts) (*vcs.UpdateResult, error) {
 	// TODO(sqs): allow use of a remote other than "origin"
 	rm, err := r.u.Remotes.Lookup("origin")
 	if err != nil {
-		return vcs.UpdateResult{}, err
+		return nil, err
 	}
 
 	rc, cfs, err := makeRemoteCallbacks(rm.Url(), opt)
 	if err != nil {
-		return vcs.UpdateResult{}, err
+		return nil, err
 	}
 	if cfs != nil {
 		defer cfs.run()
@@ -93,11 +93,11 @@ func (r *Repository) UpdateEverything(opt vcs.RemoteOpts) (vcs.UpdateResult, err
 	}
 
 	if err := rm.Fetch([]string{"+refs/*:refs/*"}, &opts, ""); err != nil {
-		return vcs.UpdateResult{}, err
+		return nil, err
 	}
 
 	// TODO: Calculate value of vcs.UpdateResult.
-	return vcs.UpdateResult{}, nil
+	return nil, nil
 }
 
 type cleanupFuncs []func() error

--- a/vcs/git/clone_update.go
+++ b/vcs/git/clone_update.go
@@ -67,22 +67,22 @@ func Clone(url, dir string, opt vcs.CloneOpt) (vcs.Repository, error) {
 		return nil, err
 	}
 	r := &Repository{Repository: cr, u: u}
-	if err := r.UpdateEverything(opt.RemoteOpts); err != nil {
+	if _, err := r.UpdateEverything(opt.RemoteOpts); err != nil {
 		return nil, err
 	}
 	return r, nil
 }
 
-func (r *Repository) UpdateEverything(opt vcs.RemoteOpts) error {
+func (r *Repository) UpdateEverything(opt vcs.RemoteOpts) (vcs.UpdateResult, error) {
 	// TODO(sqs): allow use of a remote other than "origin"
 	rm, err := r.u.Remotes.Lookup("origin")
 	if err != nil {
-		return err
+		return vcs.UpdateResult{}, err
 	}
 
 	rc, cfs, err := makeRemoteCallbacks(rm.Url(), opt)
 	if err != nil {
-		return err
+		return vcs.UpdateResult{}, err
 	}
 	if cfs != nil {
 		defer cfs.run()
@@ -93,10 +93,11 @@ func (r *Repository) UpdateEverything(opt vcs.RemoteOpts) error {
 	}
 
 	if err := rm.Fetch([]string{"+refs/*:refs/*"}, &opts, ""); err != nil {
-		return err
+		return vcs.UpdateResult{}, err
 	}
 
-	return nil
+	// TODO: Calculate value of vcs.UpdateResult.
+	return vcs.UpdateResult{}, nil
 }
 
 type cleanupFuncs []func() error

--- a/vcs/gitcmd/remote_update_parser.go
+++ b/vcs/gitcmd/remote_update_parser.go
@@ -40,9 +40,9 @@ func parseRemoteUpdateLine(line string) (vcs.Change, error) {
 	// Parse operation.
 	switch line[:3] {
 	case " * ":
-		change.Op = vcs.New
+		change.Op = vcs.NewOp
 	case "   ":
-		change.Op = vcs.Updated
+		change.Op = vcs.UpdatedOp
 	case " + ":
 		const suffix = " (forced update)"
 		if !strings.HasSuffix(line, suffix) {
@@ -50,9 +50,9 @@ func parseRemoteUpdateLine(line string) (vcs.Change, error) {
 		}
 		line = line[:len(line)-len(suffix)]
 		line = strings.TrimRightFunc(line, unicode.IsSpace)
-		change.Op = vcs.Updated
+		change.Op = vcs.UpdatedOp
 	case " x ":
-		change.Op = vcs.Deleted
+		change.Op = vcs.DeletedOp
 	default:
 		return change, fmt.Errorf("unsupported format")
 	}

--- a/vcs/gitcmd/remote_update_parser.go
+++ b/vcs/gitcmd/remote_update_parser.go
@@ -1,0 +1,80 @@
+package gitcmd
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+
+	"sourcegraph.com/sourcegraph/go-vcs/vcs"
+)
+
+// parseRemoteUpdate parses stderr output from running `git remote update`,
+// and returns a vcs.UpdateResult.
+func parseRemoteUpdate(stderr []byte) (vcs.UpdateResult, error) {
+	var result vcs.UpdateResult
+
+	lines := strings.Split(string(stderr), "\n")
+	if len(lines) < 3 { // Minimum input should have 3 lines (1 for header, 1 for change, and last empty line).
+		return result, nil
+	}
+	for _, line := range lines[1 : len(lines)-1] {
+		change, err := parseRemoteUpdateLine(line)
+		if err != nil {
+			return result, err
+		}
+		result.Changes = append(result.Changes, change)
+	}
+
+	return result, nil
+}
+
+// parseRemoteUpdateLine parses a line like `   e8569f7..de0ad17  master     -> master`.
+func parseRemoteUpdateLine(line string) (vcs.Change, error) {
+	var change vcs.Change
+
+	// Shortest valid input is len(`   d6d0813..e8569f7  m -> m`) = 27 characters.
+	if len(line) < 27 {
+		return change, fmt.Errorf("line too short")
+	}
+
+	// Parse operation.
+	switch line[:3] {
+	case " * ":
+		change.Op = vcs.New
+	case "   ":
+		change.Op = vcs.Updated
+	case " + ":
+		const suffix = " (forced update)"
+		if !strings.HasSuffix(line, suffix) {
+			return change, fmt.Errorf(`unsupported " + " format`)
+		}
+		line = line[:len(line)-len(suffix)]
+		line = strings.TrimRightFunc(line, unicode.IsSpace)
+		change.Op = vcs.Updated
+	case " x ":
+		change.Op = vcs.Deleted
+	default:
+		return change, fmt.Errorf("unsupported format")
+	}
+
+	// Parse branch name.
+	branch, err := parseBranchArrowBranch(line[21:])
+	if err != nil {
+		return change, fmt.Errorf("failed to parse branch name")
+	}
+	change.Branch = branch
+
+	return change, nil
+}
+
+// parseBranchArrowBranch parses a `master     -> master` segment to extract
+// relevant branch name. Currently always using 2nd branch name.
+func parseBranchArrowBranch(bab string) (branch string, err error) {
+	branches := strings.SplitN(bab, " -> ", 2)
+	if len(branches) != 2 {
+		return "", fmt.Errorf("failed to parse `branch -> branch` segment")
+	}
+	// Note, if we wanted to use branches[0], we should trim whitespace on its right.
+	// Return second branch name since it's always valid.
+	return branches[1], nil
+}

--- a/vcs/gitcmd/remote_update_parser.go
+++ b/vcs/gitcmd/remote_update_parser.go
@@ -42,7 +42,7 @@ func parseRemoteUpdateLine(line string) (vcs.Change, error) {
 	case " * ":
 		change.Op = vcs.NewOp
 	case "   ":
-		change.Op = vcs.UpdatedOp
+		change.Op = vcs.FFUpdatedOp
 	case " + ":
 		const suffix = " (forced update)"
 		if !strings.HasSuffix(line, suffix) {
@@ -50,7 +50,7 @@ func parseRemoteUpdateLine(line string) (vcs.Change, error) {
 		}
 		line = line[:len(line)-len(suffix)]
 		line = strings.TrimRightFunc(line, unicode.IsSpace)
-		change.Op = vcs.UpdatedOp
+		change.Op = vcs.ForceUpdatedOp
 	case " x ":
 		change.Op = vcs.DeletedOp
 	default:

--- a/vcs/gitcmd/remote_update_parser_test.go
+++ b/vcs/gitcmd/remote_update_parser_test.go
@@ -1,0 +1,103 @@
+package gitcmd
+
+import (
+	"reflect"
+	"testing"
+
+	"sourcegraph.com/sourcegraph/go-vcs/vcs"
+)
+
+func TestParseRemoteUpdate(t *testing.T) {
+	for _, tc := range []struct {
+		stderr []byte
+		want   vcs.UpdateResult
+	}{
+		{
+			stderr: []byte(""),
+			want:   vcs.UpdateResult{},
+		},
+
+		{
+			stderr: []byte(`From https://example.com/user/repo.git
+   e8569f7..de0ad17  master     -> master
+ * [new branch]      new-branch -> new-branch
+`),
+			want: vcs.UpdateResult{
+				Changes: []vcs.Change{
+					{Op: vcs.Updated, Branch: "master"},
+					{Op: vcs.New, Branch: "new-branch"},
+				},
+			},
+		},
+
+		{
+			stderr: []byte(`From https://example.com/user/repo.git
+   990cfc0..a65b539  foo-branch -> foo-branch
+   d6d0813..e8569f7  master     -> master
+`),
+			want: vcs.UpdateResult{
+				Changes: []vcs.Change{
+					{Op: vcs.Updated, Branch: "foo-branch"},
+					{Op: vcs.Updated, Branch: "master"},
+				},
+			},
+		},
+
+		{
+			stderr: []byte(`From https://example.com/user/repo.git
+ x [deleted]         (none)     -> master-backup-new-branch
+`),
+			want: vcs.UpdateResult{
+				Changes: []vcs.Change{
+					{Op: vcs.Deleted, Branch: "master-backup-new-branch"},
+				},
+			},
+		},
+
+		{
+			stderr: []byte(`From https://example.com/user/repo.git
+ * [new branch]      another-looooooong-branch-wheeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee -> another-looooooong-branch-wheeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+   de0ad17..143ee1d  master     -> master
+`),
+			want: vcs.UpdateResult{
+				Changes: []vcs.Change{
+					{Op: vcs.New, Branch: "another-looooooong-branch-wheeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"},
+					{Op: vcs.Updated, Branch: "master"},
+				},
+			},
+		},
+
+		{
+			stderr: []byte(`From https://example.com/user/repo.git
+ * [new branch]      gofmt-circleci -> gofmt-circleci
+   0bccbc3..fb8ec00  master     -> master
+ + ca1c467...939c2da refs/pull/291/merge -> refs/pull/291/merge  (forced update)
+ + 2ca958e...2cf60d2 refs/pull/334/merge -> refs/pull/334/merge  (forced update)
+ * [new ref]         refs/pull/338/head -> refs/pull/338/head
+ * [new ref]         refs/pull/344/head -> refs/pull/344/head
+ * [new ref]         refs/pull/344/merge -> refs/pull/344/merge
+`),
+			want: vcs.UpdateResult{
+				Changes: []vcs.Change{
+					{Op: vcs.New, Branch: "gofmt-circleci"},
+					{Op: vcs.Updated, Branch: "master"},
+					{Op: vcs.Updated, Branch: "refs/pull/291/merge"},
+					{Op: vcs.Updated, Branch: "refs/pull/334/merge"},
+					{Op: vcs.New, Branch: "refs/pull/338/head"},
+					{Op: vcs.New, Branch: "refs/pull/344/head"},
+					{Op: vcs.New, Branch: "refs/pull/344/merge"},
+				},
+			},
+		},
+	} {
+		got, err := parseRemoteUpdate(tc.stderr)
+		if err != nil {
+			t.Errorf("got non-nil error: %v", err)
+			continue
+		}
+		if !reflect.DeepEqual(got, tc.want) {
+			t.Errorf("got %v, want %v", got, tc.want)
+			continue
+		}
+	}
+}

--- a/vcs/gitcmd/remote_update_parser_test.go
+++ b/vcs/gitcmd/remote_update_parser_test.go
@@ -24,8 +24,8 @@ func TestParseRemoteUpdate(t *testing.T) {
 `),
 			want: vcs.UpdateResult{
 				Changes: []vcs.Change{
-					{Op: vcs.Updated, Branch: "master"},
-					{Op: vcs.New, Branch: "new-branch"},
+					{Op: vcs.UpdatedOp, Branch: "master"},
+					{Op: vcs.NewOp, Branch: "new-branch"},
 				},
 			},
 		},
@@ -37,8 +37,8 @@ func TestParseRemoteUpdate(t *testing.T) {
 `),
 			want: vcs.UpdateResult{
 				Changes: []vcs.Change{
-					{Op: vcs.Updated, Branch: "foo-branch"},
-					{Op: vcs.Updated, Branch: "master"},
+					{Op: vcs.UpdatedOp, Branch: "foo-branch"},
+					{Op: vcs.UpdatedOp, Branch: "master"},
 				},
 			},
 		},
@@ -49,7 +49,7 @@ func TestParseRemoteUpdate(t *testing.T) {
 `),
 			want: vcs.UpdateResult{
 				Changes: []vcs.Change{
-					{Op: vcs.Deleted, Branch: "master-backup-new-branch"},
+					{Op: vcs.DeletedOp, Branch: "master-backup-new-branch"},
 				},
 			},
 		},
@@ -61,8 +61,8 @@ func TestParseRemoteUpdate(t *testing.T) {
 `),
 			want: vcs.UpdateResult{
 				Changes: []vcs.Change{
-					{Op: vcs.New, Branch: "another-looooooong-branch-wheeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"},
-					{Op: vcs.Updated, Branch: "master"},
+					{Op: vcs.NewOp, Branch: "another-looooooong-branch-wheeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"},
+					{Op: vcs.UpdatedOp, Branch: "master"},
 				},
 			},
 		},
@@ -79,13 +79,13 @@ func TestParseRemoteUpdate(t *testing.T) {
 `),
 			want: vcs.UpdateResult{
 				Changes: []vcs.Change{
-					{Op: vcs.New, Branch: "gofmt-circleci"},
-					{Op: vcs.Updated, Branch: "master"},
-					{Op: vcs.Updated, Branch: "refs/pull/291/merge"},
-					{Op: vcs.Updated, Branch: "refs/pull/334/merge"},
-					{Op: vcs.New, Branch: "refs/pull/338/head"},
-					{Op: vcs.New, Branch: "refs/pull/344/head"},
-					{Op: vcs.New, Branch: "refs/pull/344/merge"},
+					{Op: vcs.NewOp, Branch: "gofmt-circleci"},
+					{Op: vcs.UpdatedOp, Branch: "master"},
+					{Op: vcs.UpdatedOp, Branch: "refs/pull/291/merge"},
+					{Op: vcs.UpdatedOp, Branch: "refs/pull/334/merge"},
+					{Op: vcs.NewOp, Branch: "refs/pull/338/head"},
+					{Op: vcs.NewOp, Branch: "refs/pull/344/head"},
+					{Op: vcs.NewOp, Branch: "refs/pull/344/merge"},
 				},
 			},
 		},

--- a/vcs/gitcmd/remote_update_parser_test.go
+++ b/vcs/gitcmd/remote_update_parser_test.go
@@ -24,7 +24,7 @@ func TestParseRemoteUpdate(t *testing.T) {
 `),
 			want: vcs.UpdateResult{
 				Changes: []vcs.Change{
-					{Op: vcs.UpdatedOp, Branch: "master"},
+					{Op: vcs.FFUpdatedOp, Branch: "master"},
 					{Op: vcs.NewOp, Branch: "new-branch"},
 				},
 			},
@@ -37,8 +37,8 @@ func TestParseRemoteUpdate(t *testing.T) {
 `),
 			want: vcs.UpdateResult{
 				Changes: []vcs.Change{
-					{Op: vcs.UpdatedOp, Branch: "foo-branch"},
-					{Op: vcs.UpdatedOp, Branch: "master"},
+					{Op: vcs.FFUpdatedOp, Branch: "foo-branch"},
+					{Op: vcs.FFUpdatedOp, Branch: "master"},
 				},
 			},
 		},
@@ -62,7 +62,7 @@ func TestParseRemoteUpdate(t *testing.T) {
 			want: vcs.UpdateResult{
 				Changes: []vcs.Change{
 					{Op: vcs.NewOp, Branch: "another-looooooong-branch-wheeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"},
-					{Op: vcs.UpdatedOp, Branch: "master"},
+					{Op: vcs.FFUpdatedOp, Branch: "master"},
 				},
 			},
 		},
@@ -80,9 +80,9 @@ func TestParseRemoteUpdate(t *testing.T) {
 			want: vcs.UpdateResult{
 				Changes: []vcs.Change{
 					{Op: vcs.NewOp, Branch: "gofmt-circleci"},
-					{Op: vcs.UpdatedOp, Branch: "master"},
-					{Op: vcs.UpdatedOp, Branch: "refs/pull/291/merge"},
-					{Op: vcs.UpdatedOp, Branch: "refs/pull/334/merge"},
+					{Op: vcs.FFUpdatedOp, Branch: "master"},
+					{Op: vcs.ForceUpdatedOp, Branch: "refs/pull/291/merge"},
+					{Op: vcs.ForceUpdatedOp, Branch: "refs/pull/334/merge"},
 					{Op: vcs.NewOp, Branch: "refs/pull/338/head"},
 					{Op: vcs.NewOp, Branch: "refs/pull/344/head"},
 					{Op: vcs.NewOp, Branch: "refs/pull/344/merge"},

--- a/vcs/gitcmd/repo.go
+++ b/vcs/gitcmd/repo.go
@@ -620,7 +620,7 @@ func (r *Repository) fetchRemote(repoDir string) error {
 	return nil
 }
 
-func (r *Repository) UpdateEverything(opt vcs.RemoteOpts) error {
+func (r *Repository) UpdateEverything(opt vcs.RemoteOpts) (vcs.UpdateResult, error) {
 	// TODO(sqs): this lock is different from libgit2's lock, but
 	// libgit2 Repositories call this method because of
 	// embedding. Therefore there could be a race condition.
@@ -640,7 +640,7 @@ func (r *Repository) UpdateEverything(opt vcs.RemoteOpts) error {
 			}
 		}()
 		if err != nil {
-			return err
+			return vcs.UpdateResult{}, err
 		}
 		defer os.Remove(gitSSHWrapper)
 		if gitSSHWrapperDir != "" {
@@ -655,7 +655,7 @@ func (r *Repository) UpdateEverything(opt vcs.RemoteOpts) error {
 
 		gitPassHelper, gitPassHelperDir, err := makeGitPassHelper(opt.HTTPS.Pass)
 		if err != nil {
-			return err
+			return vcs.UpdateResult{}, err
 		}
 		defer os.Remove(gitPassHelper)
 		if gitPassHelperDir != "" {
@@ -666,11 +666,17 @@ func (r *Repository) UpdateEverything(opt vcs.RemoteOpts) error {
 		cmd.Env = env
 	}
 
-	out, err := cmd.CombinedOutput()
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	err := cmd.Run()
 	if err != nil {
-		return fmt.Errorf("exec `git remote update` failed: %s. Output was:\n\n%s", err, out)
+		return vcs.UpdateResult{}, fmt.Errorf("exec `git remote update` failed: %v. Stderr was:\n\n%s", err, stderr.String())
 	}
-	return nil
+	result, err := parseRemoteUpdate(stderr.Bytes())
+	if err != nil {
+		return vcs.UpdateResult{}, fmt.Errorf("parsing output of `git remote update` failed: %v", err)
+	}
+	return result, nil
 }
 
 func (r *Repository) BlameFile(path string, opt *vcs.BlameOptions) ([]*vcs.Hunk, error) {

--- a/vcs/gitcmd/repo.go
+++ b/vcs/gitcmd/repo.go
@@ -620,7 +620,7 @@ func (r *Repository) fetchRemote(repoDir string) error {
 	return nil
 }
 
-func (r *Repository) UpdateEverything(opt vcs.RemoteOpts) (vcs.UpdateResult, error) {
+func (r *Repository) UpdateEverything(opt vcs.RemoteOpts) (*vcs.UpdateResult, error) {
 	// TODO(sqs): this lock is different from libgit2's lock, but
 	// libgit2 Repositories call this method because of
 	// embedding. Therefore there could be a race condition.
@@ -640,7 +640,7 @@ func (r *Repository) UpdateEverything(opt vcs.RemoteOpts) (vcs.UpdateResult, err
 			}
 		}()
 		if err != nil {
-			return vcs.UpdateResult{}, err
+			return nil, err
 		}
 		defer os.Remove(gitSSHWrapper)
 		if gitSSHWrapperDir != "" {
@@ -655,7 +655,7 @@ func (r *Repository) UpdateEverything(opt vcs.RemoteOpts) (vcs.UpdateResult, err
 
 		gitPassHelper, gitPassHelperDir, err := makeGitPassHelper(opt.HTTPS.Pass)
 		if err != nil {
-			return vcs.UpdateResult{}, err
+			return nil, err
 		}
 		defer os.Remove(gitPassHelper)
 		if gitPassHelperDir != "" {
@@ -670,13 +670,13 @@ func (r *Repository) UpdateEverything(opt vcs.RemoteOpts) (vcs.UpdateResult, err
 	cmd.Stderr = &stderr
 	err := cmd.Run()
 	if err != nil {
-		return vcs.UpdateResult{}, fmt.Errorf("exec `git remote update` failed: %v. Stderr was:\n\n%s", err, stderr.String())
+		return nil, fmt.Errorf("exec `git remote update` failed: %v. Stderr was:\n\n%s", err, stderr.String())
 	}
 	result, err := parseRemoteUpdate(stderr.Bytes())
 	if err != nil {
-		return vcs.UpdateResult{}, fmt.Errorf("parsing output of `git remote update` failed: %v", err)
+		return nil, fmt.Errorf("parsing output of `git remote update` failed: %v", err)
 	}
-	return result, nil
+	return &result, nil
 }
 
 func (r *Repository) BlameFile(path string, opt *vcs.BlameOptions) ([]*vcs.Hunk, error) {

--- a/vcs/hgcmd/repo.go
+++ b/vcs/hgcmd/repo.go
@@ -348,17 +348,18 @@ func (r *Repository) Diff(base, head vcs.CommitID, opt *vcs.DiffOptions) (*vcs.D
 	}, nil
 }
 
-func (r *Repository) UpdateEverything(opt vcs.RemoteOpts) error {
+func (r *Repository) UpdateEverything(opt vcs.RemoteOpts) (vcs.UpdateResult, error) {
 	if opt.SSH != nil {
-		return fmt.Errorf("hgcmd: ssh remote not supported")
+		return vcs.UpdateResult{}, fmt.Errorf("hgcmd: ssh remote not supported")
 	}
 	cmd := exec.Command("hg", "pull")
 	cmd.Dir = r.Dir
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("exec `hg pull` failed: %s. Output was:\n\n%s", err, out)
+		return vcs.UpdateResult{}, fmt.Errorf("exec `hg pull` failed: %s. Output was:\n\n%s", err, out)
 	}
-	return nil
+	// TODO: Calculate value of vcs.UpdateResult.
+	return vcs.UpdateResult{}, nil
 }
 
 func (r *Repository) BlameFile(path string, opt *vcs.BlameOptions) ([]*vcs.Hunk, error) {

--- a/vcs/hgcmd/repo.go
+++ b/vcs/hgcmd/repo.go
@@ -348,18 +348,18 @@ func (r *Repository) Diff(base, head vcs.CommitID, opt *vcs.DiffOptions) (*vcs.D
 	}, nil
 }
 
-func (r *Repository) UpdateEverything(opt vcs.RemoteOpts) (vcs.UpdateResult, error) {
+func (r *Repository) UpdateEverything(opt vcs.RemoteOpts) (*vcs.UpdateResult, error) {
 	if opt.SSH != nil {
-		return vcs.UpdateResult{}, fmt.Errorf("hgcmd: ssh remote not supported")
+		return nil, fmt.Errorf("hgcmd: ssh remote not supported")
 	}
 	cmd := exec.Command("hg", "pull")
 	cmd.Dir = r.Dir
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return vcs.UpdateResult{}, fmt.Errorf("exec `hg pull` failed: %s. Output was:\n\n%s", err, out)
+		return nil, fmt.Errorf("exec `hg pull` failed: %s. Output was:\n\n%s", err, out)
 	}
 	// TODO: Calculate value of vcs.UpdateResult.
-	return vcs.UpdateResult{}, nil
+	return nil, nil
 }
 
 func (r *Repository) BlameFile(path string, opt *vcs.BlameOptions) ([]*vcs.Hunk, error) {

--- a/vcs/remote.go
+++ b/vcs/remote.go
@@ -36,14 +36,14 @@ type UpdateResult struct {
 type Operation uint8
 
 const (
-	// New is a branch that was created.
-	New Operation = iota
+	// NewOp is a branch that was created.
+	NewOp Operation = iota
 
-	// Updated is a branch that was updated.
-	Updated
+	// UpdatedOp is a branch that was updated.
+	UpdatedOp
 
-	// Deleted is a branch that was deleted.
-	Deleted
+	// DeletedOp is a branch that was deleted.
+	DeletedOp
 )
 
 // Change is a single entry in the update result, representing Op done on Branch.

--- a/vcs/remote.go
+++ b/vcs/remote.go
@@ -23,5 +23,31 @@ type HTTPSConfig struct {
 type RemoteUpdater interface {
 	// UpdateEverything updates all branches, tags, etc., to match the
 	// default remote repository. The implementation is VCS-dependent.
-	UpdateEverything(RemoteOpts) error
+	// If supported by the implementation, results of update will be returned.
+	UpdateEverything(RemoteOpts) (UpdateResult, error)
+}
+
+// UpdateResult is the result of parsing output of the remote update operation.
+type UpdateResult struct {
+	Changes []Change
+}
+
+// Operation that happened to a branch.
+type Operation uint8
+
+const (
+	// New is a branch that was created.
+	New Operation = iota
+
+	// Updated is a branch that was updated.
+	Updated
+
+	// Deleted is a branch that was deleted.
+	Deleted
+)
+
+// Change is a single entry in the update result, representing Op done on Branch.
+type Change struct {
+	Op     Operation
+	Branch string
 }

--- a/vcs/remote.go
+++ b/vcs/remote.go
@@ -41,8 +41,11 @@ const (
 	// NewOp is a branch that was created.
 	NewOp Operation = iota
 
-	// UpdatedOp is a branch that was updated.
-	UpdatedOp
+	// FFUpdatedOp is a branch that was fast-forward updated.
+	FFUpdatedOp
+
+	// ForceUpdatedOp is a branch that was force updated.
+	ForceUpdatedOp
 
 	// DeletedOp is a branch that was deleted.
 	DeletedOp

--- a/vcs/remote.go
+++ b/vcs/remote.go
@@ -23,8 +23,10 @@ type HTTPSConfig struct {
 type RemoteUpdater interface {
 	// UpdateEverything updates all branches, tags, etc., to match the
 	// default remote repository. The implementation is VCS-dependent.
-	// If supported by the implementation, results of update will be returned.
-	UpdateEverything(RemoteOpts) (UpdateResult, error)
+	//
+	// If supported by the implementation, parsed results of update will be returned,
+	// otherwise it'll be nil.
+	UpdateEverything(RemoteOpts) (*UpdateResult, error)
 }
 
 // UpdateResult is the result of parsing output of the remote update operation.

--- a/vcs/repository_test.go
+++ b/vcs/repository_test.go
@@ -1625,7 +1625,7 @@ func TestRepository_UpdateEverything(t *testing.T) {
 			newCmds: []string{"touch newfile", "git add newfile", "GIT_COMMITTER_NAME=a GIT_COMMITTER_EMAIL=a@a.com GIT_COMMITTER_DATE=2006-01-02T15:04:05Z git commit -m newfile --author='a <a@a.com>' --date 2006-01-02T15:04:05Z", "git tag second"},
 			wantUpdateResult: &vcs.UpdateResult{
 				Changes: []vcs.Change{
-					{Op: vcs.UpdatedOp, Branch: "origin/master"},
+					{Op: vcs.FFUpdatedOp, Branch: "origin/master"},
 					{Op: vcs.NewOp, Branch: "second"},
 				},
 			},

--- a/vcs/repository_test.go
+++ b/vcs/repository_test.go
@@ -1625,8 +1625,8 @@ func TestRepository_UpdateEverything(t *testing.T) {
 			newCmds: []string{"touch newfile", "git add newfile", "GIT_COMMITTER_NAME=a GIT_COMMITTER_EMAIL=a@a.com GIT_COMMITTER_DATE=2006-01-02T15:04:05Z git commit -m newfile --author='a <a@a.com>' --date 2006-01-02T15:04:05Z", "git tag second"},
 			wantUpdateResult: vcs.UpdateResult{
 				Changes: []vcs.Change{
-					{Op: vcs.Updated, Branch: "origin/master"},
-					{Op: vcs.New, Branch: "second"},
+					{Op: vcs.UpdatedOp, Branch: "origin/master"},
+					{Op: vcs.NewOp, Branch: "second"},
 				},
 			},
 		},

--- a/vcs/repository_test.go
+++ b/vcs/repository_test.go
@@ -1634,7 +1634,7 @@ func TestRepository_UpdateEverything(t *testing.T) {
 			vcs: "hg", baseDir: initHgRepository(t, "touch x", "hg add x", "hg commit -m foo", "hg tag initial"), headDir: makeTmpDir(t, "hg-clone"),
 			opener:           func(dir string) (vcs.Repository, error) { return hgcmd.Open(dir) },
 			newCmds:          []string{"touch newfile", "hg add newfile", "hg commit -m newfile", "hg tag second"},
-			wantUpdateResult: vcs.UpdateResult{}, // UpdateResult calculation is not currently implemented for hg.
+			wantUpdateResult: vcs.UpdateResult{}, // TODO: Update this once UpdateResult calculation is implemented for hg.
 		},
 	}
 

--- a/vcs/repository_test.go
+++ b/vcs/repository_test.go
@@ -1617,13 +1617,13 @@ func TestRepository_UpdateEverything(t *testing.T) {
 		// mirror's origin.
 		newCmds []string
 
-		wantUpdateResult vcs.UpdateResult
+		wantUpdateResult *vcs.UpdateResult
 	}{
 		{
 			vcs: "git", baseDir: initGitRepository(t, "GIT_COMMITTER_NAME=a GIT_COMMITTER_EMAIL=a@a.com GIT_COMMITTER_DATE=2006-01-02T15:04:05Z git commit -m foo --author='a <a@a.com>' --date 2006-01-02T15:04:05Z --allow-empty", "git tag initial"), headDir: makeTmpDir(t, "git-clone"),
 			opener:  func(dir string) (vcs.Repository, error) { return gitcmd.Open(dir) },
 			newCmds: []string{"touch newfile", "git add newfile", "GIT_COMMITTER_NAME=a GIT_COMMITTER_EMAIL=a@a.com GIT_COMMITTER_DATE=2006-01-02T15:04:05Z git commit -m newfile --author='a <a@a.com>' --date 2006-01-02T15:04:05Z", "git tag second"},
-			wantUpdateResult: vcs.UpdateResult{
+			wantUpdateResult: &vcs.UpdateResult{
 				Changes: []vcs.Change{
 					{Op: vcs.UpdatedOp, Branch: "origin/master"},
 					{Op: vcs.NewOp, Branch: "second"},
@@ -1634,7 +1634,7 @@ func TestRepository_UpdateEverything(t *testing.T) {
 			vcs: "hg", baseDir: initHgRepository(t, "touch x", "hg add x", "hg commit -m foo", "hg tag initial"), headDir: makeTmpDir(t, "hg-clone"),
 			opener:           func(dir string) (vcs.Repository, error) { return hgcmd.Open(dir) },
 			newCmds:          []string{"touch newfile", "hg add newfile", "hg commit -m newfile", "hg tag second"},
-			wantUpdateResult: vcs.UpdateResult{}, // TODO: Update this once UpdateResult calculation is implemented for hg.
+			wantUpdateResult: nil, // TODO: Update this once UpdateResult calculation is implemented for hg.
 		},
 	}
 

--- a/vcs/repository_test.go
+++ b/vcs/repository_test.go
@@ -1673,7 +1673,7 @@ func TestRepository_UpdateEverything(t *testing.T) {
 		}
 
 		// update the mirror.
-		err = r.(vcs.RemoteUpdater).UpdateEverything(vcs.RemoteOpts{})
+		_, err = r.(vcs.RemoteUpdater).UpdateEverything(vcs.RemoteOpts{})
 		if err != nil {
 			t.Errorf("%s: UpdateEverything: %s", test.vcs, err)
 			continue

--- a/vcs/ssh_test.go
+++ b/vcs/ssh_test.go
@@ -131,7 +131,7 @@ func TestRepository_UpdateEverything_ssh(t *testing.T) {
 			opener:           func(dir string) (vcs.Repository, error) { return git.Open(dir) },
 			cloner:           func(url, dir string, opt vcs.CloneOpt) (vcs.Repository, error) { return git.Clone(url, dir, opt) },
 			newCmds:          []string{"git tag t0", "git checkout -b b0"},
-			wantUpdateResult: vcs.UpdateResult{}, // UpdateResult calculation is not currently implemented for git.
+			wantUpdateResult: vcs.UpdateResult{}, // TODO: Update this once UpdateResult calculation is implemented for git.
 		},
 		"git cmd": { // gitcmd
 			vcs: "git", baseDir: initGitRepository(t, gitCommands...), headDir: makeTmpDir(t, "git-update-ssh"),

--- a/vcs/ssh_test.go
+++ b/vcs/ssh_test.go
@@ -124,21 +124,21 @@ func TestRepository_UpdateEverything_ssh(t *testing.T) {
 		// mirror's origin.
 		newCmds []string
 
-		wantUpdateResult vcs.UpdateResult
+		wantUpdateResult *vcs.UpdateResult
 	}{
 		"git": { // git
 			vcs: "git", baseDir: initGitRepository(t, gitCommands...), headDir: makeTmpDir(t, "git-update-ssh"),
 			opener:           func(dir string) (vcs.Repository, error) { return git.Open(dir) },
 			cloner:           func(url, dir string, opt vcs.CloneOpt) (vcs.Repository, error) { return git.Clone(url, dir, opt) },
 			newCmds:          []string{"git tag t0", "git checkout -b b0"},
-			wantUpdateResult: vcs.UpdateResult{}, // TODO: Update this once UpdateResult calculation is implemented for git.
+			wantUpdateResult: nil, // TODO: Update this once UpdateResult calculation is implemented for git.
 		},
 		"git cmd": { // gitcmd
 			vcs: "git", baseDir: initGitRepository(t, gitCommands...), headDir: makeTmpDir(t, "git-update-ssh"),
 			opener:  func(dir string) (vcs.Repository, error) { return gitcmd.Open(dir) },
 			cloner:  func(url, dir string, opt vcs.CloneOpt) (vcs.Repository, error) { return gitcmd.Clone(url, dir, opt) },
 			newCmds: []string{"git tag t0", "git checkout -b b0"},
-			wantUpdateResult: vcs.UpdateResult{
+			wantUpdateResult: &vcs.UpdateResult{
 				Changes: []vcs.Change{
 					{Op: vcs.NewOp, Branch: "b0"},
 					{Op: vcs.NewOp, Branch: "t0"},

--- a/vcs/ssh_test.go
+++ b/vcs/ssh_test.go
@@ -140,8 +140,8 @@ func TestRepository_UpdateEverything_ssh(t *testing.T) {
 			newCmds: []string{"git tag t0", "git checkout -b b0"},
 			wantUpdateResult: vcs.UpdateResult{
 				Changes: []vcs.Change{
-					{Op: vcs.New, Branch: "b0"},
-					{Op: vcs.New, Branch: "t0"},
+					{Op: vcs.NewOp, Branch: "b0"},
+					{Op: vcs.NewOp, Branch: "t0"},
 				},
 			},
 		},

--- a/vcs/ssh_test.go
+++ b/vcs/ssh_test.go
@@ -180,7 +180,7 @@ func TestRepository_UpdateEverything_ssh(t *testing.T) {
 			}
 
 			// update the mirror.
-			err = r.(vcs.RemoteUpdater).UpdateEverything(remoteOpts)
+			_, err = r.(vcs.RemoteUpdater).UpdateEverything(remoteOpts)
 			if err != nil {
 				t.Errorf("%s: UpdateEverything: %s", label, err)
 				return


### PR DESCRIPTION
This is an early draft of a sample implementation for proposal #79. It's very easy to refactor and change it.

- Currently implemented in gitcmd backend only, the new functionality parses the output of `git remote update` operation and returns it to the caller.

- This is a breaking API change because it adds an extra return parameter to a method of RemoteUpdater interface.

- Add tests for the parser.

Resolves #79.