### PR TITLE
Windows support - fixed pass helper

### DIFF
--- a/vcs/gitcmd/repo.go
+++ b/vcs/gitcmd/repo.go
@@ -1297,7 +1297,7 @@ func makeGitPassHelper(pass string) (passHelper string, tempDir string, err erro
 	var script string
 
 	if runtime.GOOS == "windows" {
-		script = "@echo off\necho '" + pass + "'\n"
+		script = "@echo off\necho " + pass + "\n"
 	} else {
 		script = "#!/bin/sh\necho '" + pass + "'\n"
 	}


### PR DESCRIPTION
- removed single quotes around password in pass helper, because Windows echo prints them as well