### PR TITLE
gitcmd: Correctly escape passwords

### DIFF
--- a/vcs/gitcmd/repo.go
+++ b/vcs/gitcmd/repo.go
@@ -1294,12 +1294,21 @@ func makeGitPassHelper(pass string) (passHelper string, tempDir string, err erro
 		return tmpFile, dir, err
 	}
 
+	passPath := filepath.Join(dir, "password")
+	err = internal.WriteFileWithPermissions(passPath, []byte(pass), 0600)
+	if err != nil {
+		return tmpFile, dir, err
+	}
+
 	var script string
 
+	// We assume passPath can be escaped with a simple wrapping of single
+	// quotes. The path is not user controlled so this assumption should
+	// not be violated.
 	if runtime.GOOS == "windows" {
-		script = "@echo off\necho '" + pass + "'\n"
+		script = "@echo off\ntype " + passPath + "\n"
 	} else {
-		script = "#!/bin/sh\necho '" + pass + "'\n"
+		script = "#!/bin/sh\ncat '" + passPath + "'\n"
 	}
 
 	err = internal.WriteFileWithPermissions(tmpFile, []byte(script), 0500)

--- a/vcs/internal/script.go
+++ b/vcs/internal/script.go
@@ -11,27 +11,20 @@ import (
 // On Windows such a file must have .bat extension
 // Returns triplet where
 // - filePath is a location of file
-// - rootPath may refer to temporary root directory
+// - rootPath refers to temporary root directory the filePath is in
 // (everything under the rootPath (including rootPath) should be removed when no longer needed)
-// rootPath makes sense on Windows only where location of script file is TEMP_DIR()/RANDOM_DIR()/FILE.bat
 // - error indicates possible error
 func ScriptFile(prefix string) (filePath string, rootPath string, err error) {
-
+	var suffix string
 	if runtime.GOOS == "windows" {
-		// making unique temporary directory and file inside it
-		tempDir, err := ioutil.TempDir("", prefix)
-		if err != nil {
-			return "", "", err
-		}
-		return filepath.Join(tempDir, prefix+".bat"), tempDir, nil
-	} else {
-		tf, err := ioutil.TempFile("", prefix)
-		if err != nil {
-			return "", "", err
-		}
-		tf.Close()
-		return filepath.ToSlash(tf.Name()), "", nil
+		suffix = ".bat"
 	}
+
+	tempDir, err := ioutil.TempDir("", prefix)
+	if err != nil {
+		return "", "", err
+	}
+	return filepath.Join(tempDir, prefix+suffix), tempDir, nil
 }
 
 // Wrapper around ioutil.WriteFile that updates permissions regardless if file existed before

--- a/vcs/internal/script_test.go
+++ b/vcs/internal/script_test.go
@@ -1,0 +1,48 @@
+package internal
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestScriptFile(t *testing.T) {
+	p, dir, err := ScriptFile("hi")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if filepath.Dir(p) != dir {
+		t.Errorf("Expected %s to be in %s", p, dir)
+	}
+	// Only do remove when we get here just in case we return something
+	// silly
+	defer os.RemoveAll(dir)
+
+	textPath := filepath.Join(dir, "text")
+	err = WriteFileWithPermissions(textPath, []byte("Hello World!"), 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var script string
+	if runtime.GOOS == "windows" {
+		script = "@echo off\ntype " + textPath + "\n"
+	} else {
+		script = "#!/bin/sh\ncat '" + textPath + "'\n"
+	}
+	err = WriteFileWithPermissions(p, []byte(script), 0500)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := exec.Command(p).CombinedOutput()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(out) != "Hello World!" {
+		t.Errorf("Unexpected output from script: %v", string(out))
+	}
+}


### PR DESCRIPTION
We avoid the need to do unix/batch escaping entirely by just outputting the file
in the script.