### PR TITLE
vcs/gitcmd: use 'git remote update --prune' option

### DIFF
--- a/vcs/gitcmd/repo.go
+++ b/vcs/gitcmd/repo.go
@@ -627,7 +627,7 @@ func (r *Repository) UpdateEverything(opt vcs.RemoteOpts) error {
 	r.editLock.Lock()
 	defer r.editLock.Unlock()
 
-	cmd := exec.Command("git", "remote", "update")
+	cmd := exec.Command("git", "remote", "update", "--prune")
 	cmd.Dir = r.Dir
 
 	if opt.SSH != nil {


### PR DESCRIPTION
Prior to this change we would not use the `--prune` flag which removes
any remote-tracking references that no longer exist on the remote after
updating.

In our app, this caused mirrored repositories updated via `UpdateEverything`
to have branches that cannot ever be deleted (by deleting the branch from
remote).