### PR TITLE
vcs/util/tracer: add a utility package for recording VCS operations to Appdash

### DIFF
--- a/vcs/util/tracer/repository.go
+++ b/vcs/util/tracer/repository.go
@@ -1,0 +1,135 @@
+package tracer
+
+import (
+	"fmt"
+	"time"
+
+	"golang.org/x/tools/godoc/vfs"
+	"sourcegraph.com/sourcegraph/appdash"
+	"sourcegraph.com/sourcegraph/go-vcs/vcs"
+)
+
+// repository implements the vcs.Repository interface.
+type repository struct {
+	r   vcs.Repository
+	rec *appdash.Recorder
+}
+
+// ResolveRevision implements the vcs.Repository interface.
+func (r repository) ResolveRevision(spec string) (vcs.CommitID, error) {
+	start := time.Now()
+	rev, err := r.r.ResolveRevision(spec)
+	r.rec.Child().Event(GoVCS{
+		Name:      "vcs.Repository.ResolveRevision",
+		Args:      fmt.Sprintf("%#v", spec),
+		StartTime: start,
+		EndTime:   time.Now(),
+	})
+	return rev, err
+}
+
+// ResolveTag implements the vcs.Repository interface.
+func (r repository) ResolveTag(name string) (vcs.CommitID, error) {
+	start := time.Now()
+	tag, err := r.r.ResolveTag(name)
+	r.rec.Child().Event(GoVCS{
+		Name:      "vcs.Repository.ResolveTag",
+		Args:      fmt.Sprintf("%#v", name),
+		StartTime: start,
+		EndTime:   time.Now(),
+	})
+	return tag, err
+}
+
+// ResolveBranch implements the vcs.Repository interface.
+func (r repository) ResolveBranch(name string) (vcs.CommitID, error) {
+	start := time.Now()
+	branch, err := r.r.ResolveBranch(name)
+	r.rec.Child().Event(GoVCS{
+		Name:      "vcs.Repository.ResolveBranch",
+		Args:      fmt.Sprintf("%#v", name),
+		StartTime: start,
+		EndTime:   time.Now(),
+	})
+	return branch, err
+}
+
+// Branches implements the vcs.Repository interface.
+func (r repository) Branches(opt vcs.BranchesOptions) ([]*vcs.Branch, error) {
+	start := time.Now()
+	branches, err := r.r.Branches(opt)
+	r.rec.Child().Event(GoVCS{
+		Name:      "vcs.Repository.Branches",
+		Args:      fmt.Sprintf("%#v", opt),
+		StartTime: start,
+		EndTime:   time.Now(),
+	})
+	return branches, err
+}
+
+// Tags implements the vcs.Repository interface.
+func (r repository) Tags() ([]*vcs.Tag, error) {
+	start := time.Now()
+	tags, err := r.r.Tags()
+	r.rec.Child().Event(GoVCS{
+		Name:      "vcs.Repository.Tags",
+		StartTime: start,
+		EndTime:   time.Now(),
+	})
+	return tags, err
+}
+
+// GetCommit implements the vcs.Repository interface.
+func (r repository) GetCommit(commitID vcs.CommitID) (*vcs.Commit, error) {
+	start := time.Now()
+	commit, err := r.r.GetCommit(commitID)
+	r.rec.Child().Event(GoVCS{
+		Name:      "vcs.Repository.GetCommit",
+		Args:      fmt.Sprintf("%#v", commitID),
+		StartTime: start,
+		EndTime:   time.Now(),
+	})
+	return commit, err
+}
+
+// Commits implements the vcs.Repository interface.
+func (r repository) Commits(opt vcs.CommitsOptions) (commits []*vcs.Commit, total uint, err error) {
+	start := time.Now()
+	commits, total, err = r.r.Commits(opt)
+	r.rec.Child().Event(GoVCS{
+		Name:      "vcs.Repository.Commits",
+		Args:      fmt.Sprintf("%#v", opt),
+		StartTime: start,
+		EndTime:   time.Now(),
+	})
+	return commits, total, err
+}
+
+// Committers implements the vcs.Repository interface.
+func (r repository) Committers(opt vcs.CommittersOptions) ([]*vcs.Committer, error) {
+	start := time.Now()
+	committers, err := r.r.Committers(opt)
+	r.rec.Child().Event(GoVCS{
+		Name:      "vcs.Repository.Committers",
+		Args:      fmt.Sprintf("%#v", opt),
+		StartTime: start,
+		EndTime:   time.Now(),
+	})
+	return committers, err
+}
+
+// FileSystem implements the vcs.Repository interface.
+func (r repository) FileSystem(at vcs.CommitID) (vfs.FileSystem, error) {
+	start := time.Now()
+	fs, err := r.r.FileSystem(at)
+	r.rec.Child().Event(GoVCS{
+		Name:      "vcs.Repository.FileSystem",
+		Args:      fmt.Sprintf("%#v", at),
+		StartTime: start,
+		EndTime:   time.Now(),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return fileSystem{fs: fs, rec: r.rec}, nil
+}

--- a/vcs/util/tracer/tracer.go
+++ b/vcs/util/tracer/tracer.go
@@ -1,0 +1,132 @@
+package tracer
+
+import (
+	"fmt"
+	"time"
+
+	"sourcegraph.com/sourcegraph/appdash"
+	"sourcegraph.com/sourcegraph/go-vcs/vcs"
+)
+
+func init() { appdash.RegisterEvent(GoVCS{}) }
+
+// GoVCS records a go-vcs method invocation.
+type GoVCS struct {
+	Name, Args string
+
+	StartTime time.Time
+	EndTime   time.Time
+}
+
+// Schema returns the constant "GoVCS".
+func (GoVCS) Schema() string { return "GoVCS" }
+
+func (e GoVCS) Start() time.Time { return e.StartTime }
+func (e GoVCS) End() time.Time   { return e.EndTime }
+
+// Wrap wraps the given VCS repository, returning a repository which emits
+// tracing events.
+func Wrap(r vcs.Repository, rec *appdash.Recorder) vcs.Repository {
+	// Wrap the repository.
+	t := repository{r: r, rec: rec}
+
+	// Also wrap optional interface.
+	final := vcs.Repository(t)
+	if b, ok := r.(vcs.Blamer); ok {
+		final = blamer{Repository: final, b: b, rec: rec}
+	}
+	if d, ok := r.(vcs.Differ); ok {
+		final = differ{Repository: final, d: d, rec: rec}
+	}
+	if c, ok := r.(vcs.CrossRepoDiffer); ok {
+		final = crossRepoDiffer{Repository: final, c: c, rec: rec}
+	}
+	if f, ok := r.(vcs.FileLister); ok {
+		final = fileLister{Repository: final, f: f, rec: rec}
+	}
+	return final
+}
+
+// blamer implements the vcs.Repository interface, adding a wrapped vcs.Blamer
+// implementation.
+type blamer struct {
+	vcs.Repository
+	b   vcs.Blamer
+	rec *appdash.Recorder
+}
+
+// BlameFile implements the vcs.Blamer interface.
+func (b blamer) BlameFile(path string, opt *vcs.BlameOptions) ([]*vcs.Hunk, error) {
+	start := time.Now()
+	hunks, err := b.b.BlameFile(path, opt)
+	b.rec.Child().Event(GoVCS{
+		Name:      "vcs.Blamer.BlameFile",
+		Args:      fmt.Sprintf("%#v, %#v", path, opt),
+		StartTime: start,
+		EndTime:   time.Now(),
+	})
+	return hunks, err
+}
+
+// differ implements the vcs.Repository interface, adding a wrapped vcs.Differ
+// implementation.
+type differ struct {
+	vcs.Repository
+	d   vcs.Differ
+	rec *appdash.Recorder
+}
+
+// Diff implements the vcs.Differ interface.
+func (d differ) Diff(base, head vcs.CommitID, opt *vcs.DiffOptions) (*vcs.Diff, error) {
+	start := time.Now()
+	diff, err := d.d.Diff(base, head, opt)
+	d.rec.Child().Event(GoVCS{
+		Name:      "vcs.Differ.Diff",
+		Args:      fmt.Sprintf("%#v, %#v, %#v", base, head, opt),
+		StartTime: start,
+		EndTime:   time.Now(),
+	})
+	return diff, err
+}
+
+// crossRepoDiffer implements the vcs.Repository interface, adding a wrapped
+// vcs.CrossRepoDiffer implementation.
+type crossRepoDiffer struct {
+	vcs.Repository
+	c   vcs.CrossRepoDiffer
+	rec *appdash.Recorder
+}
+
+// CrossRepoDiff implements the vcs.CrossRepoDiffer interface.
+func (c crossRepoDiffer) CrossRepoDiff(base vcs.CommitID, headRepo vcs.Repository, head vcs.CommitID, opt *vcs.DiffOptions) (*vcs.Diff, error) {
+	start := time.Now()
+	diff, err := c.c.CrossRepoDiff(base, headRepo, head, opt)
+	c.rec.Child().Event(GoVCS{
+		Name:      "vcs.CrossRepoDiffer.CrossRepoDiff",
+		Args:      fmt.Sprintf("%#v, %#v, %#v, %#v", base, headRepo, head, opt),
+		StartTime: start,
+		EndTime:   time.Now(),
+	})
+	return diff, err
+}
+
+// fileLister implements the vcs.Repository interface, adding a wrapped
+// vcs.FileListener implementation.
+type fileLister struct {
+	vcs.Repository
+	f   vcs.FileLister
+	rec *appdash.Recorder
+}
+
+// ListFiles implements the vcs.FileLister interface.
+func (f fileLister) ListFiles(commit vcs.CommitID) ([]string, error) {
+	start := time.Now()
+	files, err := f.f.ListFiles(commit)
+	f.rec.Child().Event(GoVCS{
+		Name:      "vcs.FileLister.ListFiles",
+		Args:      fmt.Sprintf("%#v", commit),
+		StartTime: start,
+		EndTime:   time.Now(),
+	})
+	return files, err
+}

--- a/vcs/util/tracer/vfs.go
+++ b/vcs/util/tracer/vfs.go
@@ -1,0 +1,104 @@
+package tracer
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"golang.org/x/tools/godoc/vfs"
+	"sourcegraph.com/sourcegraph/appdash"
+)
+
+// readSeekCloser implements the vfs.ReadSeekCloser interface and emits a single
+// event upon close (lightly representitive of time it took to read the file).
+type readSeekCloser struct {
+	vfs.ReadSeekCloser
+	start time.Time
+	name  string
+	rec   *appdash.Recorder
+}
+
+// Close implements the io.Closer interface.
+func (r readSeekCloser) Close() error {
+	err := r.ReadSeekCloser.Close()
+	r.rec.Child().Event(GoVCS{
+		Name:      "vcs.Repository.FileSystem.Open -> Close",
+		Args:      r.name,
+		StartTime: r.start,
+		EndTime:   time.Now(),
+	})
+	return err
+}
+
+// fileSystem implements the vfs.FileSystem interface.
+type fileSystem struct {
+	fs  vfs.FileSystem
+	rec *appdash.Recorder
+}
+
+// Open implements the vfs.Opener interface.
+func (fs fileSystem) Open(name string) (vfs.ReadSeekCloser, error) {
+	// TODO(slimsag): track time to Close
+	start := time.Now()
+	f, err := fs.fs.Open(name)
+	end := time.Now()
+	fs.rec.Child().Event(GoVCS{
+		Name:      "vcs.Repository.FileSystem.Open",
+		Args:      name,
+		StartTime: start,
+		EndTime:   end,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return readSeekCloser{
+		ReadSeekCloser: f,
+		start:          end,
+		name:           name,
+		rec:            fs.rec,
+	}, nil
+}
+
+// Lstat implements the vfs.FileSystem interface.
+func (fs fileSystem) Lstat(path string) (os.FileInfo, error) {
+	start := time.Now()
+	fi, err := fs.fs.Lstat(path)
+	fs.rec.Child().Event(GoVCS{
+		Name:      "vcs.Repository.FileSystem.Lstat",
+		Args:      fmt.Sprintf("%#v", path),
+		StartTime: start,
+		EndTime:   time.Now(),
+	})
+	return fi, err
+}
+
+// Stat implements the vfs.FileSystem interface.
+func (fs fileSystem) Stat(path string) (os.FileInfo, error) {
+	start := time.Now()
+	fi, err := fs.fs.Stat(path)
+	fs.rec.Child().Event(GoVCS{
+		Name:      "vcs.Repository.FileSystem.Stat",
+		Args:      fmt.Sprintf("%#v", path),
+		StartTime: start,
+		EndTime:   time.Now(),
+	})
+	return fi, err
+}
+
+// ReadDir implements the vfs.FileSystem interface.
+func (fs fileSystem) ReadDir(path string) ([]os.FileInfo, error) {
+	start := time.Now()
+	fis, err := fs.fs.ReadDir(path)
+	fs.rec.Child().Event(GoVCS{
+		Name:      "vcs.Repository.FileSystem.ReadDir",
+		Args:      fmt.Sprintf("%#v", path),
+		StartTime: start,
+		EndTime:   time.Now(),
+	})
+	return fis, err
+}
+
+// String implements the vfs.FileSystem interface.
+func (fs fileSystem) String() string {
+	return fs.fs.String()
+}

--- a/vcs/util/tracer/vfs.go
+++ b/vcs/util/tracer/vfs.go
@@ -38,7 +38,6 @@ type fileSystem struct {
 
 // Open implements the vfs.Opener interface.
 func (fs fileSystem) Open(name string) (vfs.ReadSeekCloser, error) {
-	// TODO(slimsag): track time to Close
 	start := time.Now()
 	f, err := fs.fs.Open(name)
 	end := time.Now()


### PR DESCRIPTION
This change adds a utility package which records VCS operations to an `*appdash.Recorder`
by wrapping a `vcs.Repository` value. It implements the optional interface types
that a `vcs.Repository` implementation may opt-in to, so no functionality is
lost. Because it works at the interface level we can trace all different
backends (`gitcmd`, `git`, `hg`, etc) without writing new tracing code.

In Appdash, all events are prefixed with `vcs.Type` for easier filtering:

![screenshot](http://virtivia.com:27080/1nt70brhgfma7.png)