### PR TITLE
vcs/util/tracer: fix CrossRepoDiffer in gitcmd backend

### DIFF
--- a/vcs/util/tracer/gitcmd.go
+++ b/vcs/util/tracer/gitcmd.go
@@ -1,0 +1,26 @@
+package tracer
+
+import (
+	"time"
+
+	"sourcegraph.com/sourcegraph/appdash"
+	"sourcegraph.com/sourcegraph/go-vcs/vcs/gitcmd"
+)
+
+// gitcmdCrossRepo wraps a gitcmd.CrossRepo, adding tracing to it.
+type gitcmdCrossRepo struct {
+	c   gitcmd.CrossRepo
+	rec *appdash.Recorder
+}
+
+// GitRootDir implements the gitcmd.CrossRepo interface.
+func (c gitcmdCrossRepo) GitRootDir() string {
+	start := time.Now()
+	dir := c.c.GitRootDir()
+	c.rec.Child().Event(GoVCS{
+		Name:      "gitcmd.CrossRepo.GitRootDir",
+		StartTime: start,
+		EndTime:   time.Now(),
+	})
+	return dir
+}

--- a/vcs/util/tracer/tracer.go
+++ b/vcs/util/tracer/tracer.go
@@ -47,14 +47,14 @@ func Wrap(r vcs.Repository, rec *appdash.Recorder) vcs.Repository {
 	realSearcher, isSearcher := r.(vcs.Searcher)
 
 	// Wrap the optional interfaces.
-	blamer := blamer{repository: t, b: realBlamer, rec: rec}
-	differ := differ{repository: t, d: realDiffer, rec: rec}
-	crossRepoDiffer := crossRepoDiffer{repository: t, c: realCrossRepoDiffer, rec: rec}
-	fileLister := fileLister{repository: t, f: realFileLister, rec: rec}
-	merger := merger{repository: t, m: realMerger, rec: rec}
-	crossRepoMerger := crossRepoMerger{repository: t, m: realCrossRepoMerger, rec: rec}
-	remoteUpdater := remoteUpdater{repository: t, r: realRemoteUpdater, rec: rec}
-	searcher := searcher{repository: t, s: realSearcher, rec: rec}
+	blamer := blamer{b: realBlamer, rec: rec}
+	differ := differ{d: realDiffer, rec: rec}
+	crossRepoDiffer := crossRepoDiffer{c: realCrossRepoDiffer, rec: rec}
+	fileLister := fileLister{f: realFileLister, rec: rec}
+	merger := merger{m: realMerger, rec: rec}
+	crossRepoMerger := crossRepoMerger{m: realCrossRepoMerger, rec: rec}
+	remoteUpdater := remoteUpdater{r: realRemoteUpdater, rec: rec}
+	searcher := searcher{s: realSearcher, rec: rec}
 
 	// Return a union of all optional interfaces that the input vcs.Repository
 	// implements.
@@ -140,10 +140,8 @@ func Wrap(r vcs.Repository, rec *appdash.Recorder) vcs.Repository {
 	}
 }
 
-// blamer implements the vcs.Repository interface, adding a wrapped vcs.Blamer
-// implementation.
+// blamer wraps a vcs.Blamer, adding tracing to it.
 type blamer struct {
-	repository
 	b   vcs.Blamer
 	rec *appdash.Recorder
 }
@@ -161,10 +159,8 @@ func (b blamer) BlameFile(path string, opt *vcs.BlameOptions) ([]*vcs.Hunk, erro
 	return hunks, err
 }
 
-// differ implements the vcs.Repository interface, adding a wrapped vcs.Differ
-// implementation.
+// differ wraps a vcs.Differ, adding tracing to it.
 type differ struct {
-	repository
 	d   vcs.Differ
 	rec *appdash.Recorder
 }
@@ -182,10 +178,8 @@ func (d differ) Diff(base, head vcs.CommitID, opt *vcs.DiffOptions) (*vcs.Diff, 
 	return diff, err
 }
 
-// crossRepoDiffer implements the vcs.Repository interface, adding a wrapped
-// vcs.CrossRepoDiffer implementation.
+// crossRepoDiffer wraps a vcs.CrossRepoDiffer, adding tracing to it.
 type crossRepoDiffer struct {
-	repository
 	c   vcs.CrossRepoDiffer
 	rec *appdash.Recorder
 }
@@ -203,10 +197,8 @@ func (c crossRepoDiffer) CrossRepoDiff(base vcs.CommitID, headRepo vcs.Repositor
 	return diff, err
 }
 
-// fileLister implements the vcs.Repository interface, adding a wrapped
-// vcs.FileListener implementation.
+// fileLister wraps a vcs.FileListener, adding tracing to it.
 type fileLister struct {
-	repository
 	f   vcs.FileLister
 	rec *appdash.Recorder
 }
@@ -224,10 +216,8 @@ func (f fileLister) ListFiles(commit vcs.CommitID) ([]string, error) {
 	return files, err
 }
 
-// merger implements the vcs.Repository interface, adding a wrapped vcs.Merger
-// implementation.
+// merger wraps a vcs.Merger, adding tracing to it.
 type merger struct {
-	repository
 	m   vcs.Merger
 	rec *appdash.Recorder
 }
@@ -245,10 +235,8 @@ func (m merger) MergeBase(a vcs.CommitID, b vcs.CommitID) (vcs.CommitID, error) 
 	return commit, err
 }
 
-// crossRepoMerger implements the vcs.Repository interface, adding a wrapped
-// vcs.CrossRepoMerger implementation.
+// crossRepoMerger wraps a vcs.CrossRepoMerger, adding tracing to it.
 type crossRepoMerger struct {
-	repository
 	m   vcs.CrossRepoMerger
 	rec *appdash.Recorder
 }
@@ -266,10 +254,8 @@ func (m crossRepoMerger) CrossRepoMergeBase(a vcs.CommitID, repoB vcs.Repository
 	return commit, err
 }
 
-// remoteUpdater implements the vcs.Repository interface, adding a wrapped
-// vcs.RemoteUpdater implementation.
+// remoteUpdater wraps a vcs.RemoteUpdater, adding tracing to it.
 type remoteUpdater struct {
-	repository
 	r   vcs.RemoteUpdater
 	rec *appdash.Recorder
 }
@@ -287,10 +273,8 @@ func (r remoteUpdater) UpdateEverything(opts vcs.RemoteOpts) (*vcs.UpdateResult,
 	return result, err
 }
 
-// searcher implements the vcs.Repository interface, adding a wrapped
-// vcs.Searcher implementation.
+// searcher wraps a vcs.Searcher, adding tracing to it.
 type searcher struct {
-	repository
 	s   vcs.Searcher
 	rec *appdash.Recorder
 }


### PR DESCRIPTION
This fixes the last failing test on CI for our main repo so that [we can merge support for tracing git operations](https://src.sourcegraph.com/sourcegraph/.changes/372).

Note: this is a follow-up to https://github.com/sourcegraph/go-vcs/pull/85