### PR TITLE
vcs/gitcmd: unset GIT_ASKPASS prior to appension

### DIFF
--- a/vcs/gitcmd/repo.go
+++ b/vcs/gitcmd/repo.go
@@ -119,6 +119,7 @@ func Clone(url, dir string, opt vcs.CloneOpt) (*Repository, error) {
 		if gitPassHelperDir != "" {
 			defer os.RemoveAll(gitPassHelperDir)
 		}
+		env.Unset("GIT_ASKPASS")
 		env = append(env, "GIT_ASKPASS="+gitPassHelper)
 
 		cmd.Env = env


### PR DESCRIPTION
or else the new one will not take effect if there is a prior one in play.

This was discovered to be incorrect as part of a [separate / unrelated change](https://src.sourcegraph.com/sourcegraph/.commits/597229995ed0bd8f5e89915cb4cdeb25caa87eb3), but nonetheless was incorrect code.