### PR TITLE
all: Add RootType method to vfs.FileSystem implementations.

### DIFF
--- a/vcs/git/vfs.go
+++ b/vcs/git/vfs.go
@@ -240,6 +240,8 @@ func (fs *filesystem) ReadDir(path string) ([]os.FileInfo, error) {
 	return fis, nil
 }
 
+func (*filesystem) RootType(string) vfs.RootType { return "" }
+
 func (fs *filesystem) String() string {
 	return fmt.Sprintf("git repository %s commit %s (gogit)", fs.dir, fs.oid)
 }

--- a/vcs/gitcmd/repo.go
+++ b/vcs/gitcmd/repo.go
@@ -1267,6 +1267,8 @@ func (fs *gitFSCmd) lsTree(path string) ([]os.FileInfo, error) {
 	return fis, nil
 }
 
+func (*gitFSCmd) RootType(string) vfs.RootType { return "" }
+
 func (fs *gitFSCmd) String() string {
 	return fmt.Sprintf("git repository %s commit %s (cmd)", fs.dir, fs.at)
 }

--- a/vcs/hg/repo.go
+++ b/vcs/hg/repo.go
@@ -558,6 +558,8 @@ func (fs *hgFSNative) ReadDir(path string) ([]os.FileInfo, error) {
 	return fis, nil
 }
 
+func (*hgFSNative) RootType(string) vfs.RootType { return "" }
+
 func (fs *hgFSNative) String() string {
 	return fmt.Sprintf("hg repository %s commit %s (native)", fs.dir, fs.at)
 }

--- a/vcs/hgcmd/repo.go
+++ b/vcs/hgcmd/repo.go
@@ -546,6 +546,8 @@ func (fs *hgFSCmd) ReadDir(path string) ([]os.FileInfo, error) {
 	return fis, nil
 }
 
+func (*hgFSCmd) RootType(string) vfs.RootType { return "" }
+
 func (fs *hgFSCmd) String() string {
 	return fmt.Sprintf("hg repository %s commit %s (cmd)", fs.dir, fs.at)
 }

--- a/vcs/util/tracer/vfs.go
+++ b/vcs/util/tracer/vfs.go
@@ -97,6 +97,9 @@ func (fs fileSystem) ReadDir(path string) ([]os.FileInfo, error) {
 	return fis, err
 }
 
+// RootType implements the vfs.FileSystem interface.
+func (fileSystem) RootType(string) vfs.RootType { return "" }
+
 // String implements the vfs.FileSystem interface.
 func (fs fileSystem) String() string {
 	return fs.fs.String()


### PR DESCRIPTION
It is needed to continue to implement the [`vfs.FileSystem`](https://godoc.org/golang.org/x/tools/godoc/vfs#FileSystem) interface after golang/tools@16d1af8d88c08b6a22e07a0900aad5279a7fb4fd.

Fixes #100.