### PR TITLE
vcs/gitcmd: Always provide -- separator.

### DIFF
--- a/vcs/gitcmd/repo.go
+++ b/vcs/gitcmd/repo.go
@@ -455,8 +455,9 @@ func (r *Repository) commitLog(opt vcs.CommitsOptions) ([]*vcs.Commit, uint, err
 	}
 	args = append(args, rng)
 
+	args = append(args, "--")
 	if opt.Path != "" {
-		args = append(args, "--", opt.Path)
+		args = append(args, opt.Path)
 	}
 
 	cmd := exec.Command("git", args...)


### PR DESCRIPTION
The `--` separator is optional, but always providing it helps avoid arguments being ambiguous in some situations.

Below is an example of when the base branch does not exist.

Before:

	exec `git log` failed: exit status 128. Output was:

	fatal: ambiguous argument 'notexist': unknown revision or path not in the working tree.
	Use '--' to separate paths from revisions, like this:
	'git <command> [<revision>...] -- [<file>...]'

After:

	exec `git log` failed: exit status 128. Output was:

	fatal: bad revision 'notexist'

The new error is better because we can map it to `vcs.ErrCommitNotFound` rather than a generic unknown error type. This will be done in next PR.