### PR TITLE
vcs/gitcmd: Use correct commit range in commitLog.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 sudo: false
 language: go
 go:
-  - "1.5.x"
   - "1.x"
+  - "1.9.x"
   - master
 matrix:
   allow_failures:

--- a/vcs/gitcmd/repo.go
+++ b/vcs/gitcmd/repo.go
@@ -451,7 +451,7 @@ func (r *Repository) commitLog(opt vcs.CommitsOptions) ([]*vcs.Commit, uint, err
 	// Range
 	rng := string(opt.Head)
 	if opt.Base != "" {
-		rng += "..." + string(opt.Base)
+		rng = string(opt.Base) + ".." + string(opt.Head)
 	}
 	args = append(args, rng)
 

--- a/vcs/repository.go
+++ b/vcs/repository.go
@@ -126,7 +126,7 @@ func (c *CommitID) Unmarshal(data []byte) error {
 // (Repository).Commits.
 type CommitsOptions struct {
 	Head CommitID // include all commits reachable from this commit (required)
-	Base CommitID // exlude all commits reachable from this commit (optional, like `git log Base..Head`)
+	Base CommitID // exclude all commits reachable from this commit (optional, like `git log Base..Head`)
 
 	N    uint // limit the number of returned commits to this many (0 means no limit)
 	Skip uint // skip this many commits at the beginning

--- a/vcs/repository_test.go
+++ b/vcs/repository_test.go
@@ -969,6 +969,13 @@ func TestRepository_Commits_options(t *testing.T) {
 			Message:   "qux",
 			Parents:   []vcs.CommitID{"b266c7e3ca00b1a17ad0b1449825d0854225c007"},
 		},
+		{
+			ID:        "b266c7e3ca00b1a17ad0b1449825d0854225c007",
+			Author:    vcs.Signature{"a", "a@a.com", mustParseTime(time.RFC3339, "2006-01-02T15:04:06Z")},
+			Committer: &vcs.Signature{"c", "c@c.com", mustParseTime(time.RFC3339, "2006-01-02T15:04:07Z")},
+			Message:   "bar",
+			Parents:   []vcs.CommitID{"ea167fe3d76b1e5fd3ed8ca44cbd2fe3897684f8"},
+		},
 	}
 	hgCommands := []string{
 		"touch --date=2006-01-02T15:04:05Z f || touch -t " + times[0] + " f",
@@ -1009,23 +1016,41 @@ func TestRepository_Commits_options(t *testing.T) {
 			wantCommits: wantGitCommits,
 			wantTotal:   3,
 		},
-		"git cmd Head": {
+		"git cmd Base..Head": {
 			repo: makeGitRepositoryCmd(t, gitCommands...),
 			opt: vcs.CommitsOptions{
 				Head: "ade564eba4cf904492fb56dcd287ac633e6e082c",
-				Base: "b266c7e3ca00b1a17ad0b1449825d0854225c007",
+				Base: "ea167fe3d76b1e5fd3ed8ca44cbd2fe3897684f8",
 			},
 			wantCommits: wantGitCommits2,
-			wantTotal:   1,
+			wantTotal:   2,
 		},
-		"git go-git Head": {
+		"git go-git Base..Head": {
 			repo: makeGitRepositoryGoGit(t, gitCommands...),
 			opt: vcs.CommitsOptions{
 				Head: "ade564eba4cf904492fb56dcd287ac633e6e082c",
-				Base: "b266c7e3ca00b1a17ad0b1449825d0854225c007",
+				Base: "ea167fe3d76b1e5fd3ed8ca44cbd2fe3897684f8",
 			},
 			wantCommits: wantGitCommits2,
-			wantTotal:   1,
+			wantTotal:   2,
+		},
+		"git cmd Base..Head (empty)": {
+			repo: makeGitRepositoryCmd(t, gitCommands...),
+			opt: vcs.CommitsOptions{
+				Head: "b266c7e3ca00b1a17ad0b1449825d0854225c007",
+				Base: "ade564eba4cf904492fb56dcd287ac633e6e082c",
+			},
+			wantCommits: nil,
+			wantTotal:   0,
+		},
+		"git go-git Base..Head (empty)": {
+			repo: makeGitRepositoryGoGit(t, gitCommands...),
+			opt: vcs.CommitsOptions{
+				Head: "b266c7e3ca00b1a17ad0b1449825d0854225c007",
+				Base: "ade564eba4cf904492fb56dcd287ac633e6e082c",
+			},
+			wantCommits: nil,
+			wantTotal:   0,
 		},
 		"hg native": {
 			repo:        makeHgRepositoryNative(t, hgCommands...),


### PR DESCRIPTION
[`vcs.CommitsOptions`](https://godoc.org/sourcegraph.com/sourcegraph/go-vcs/vcs#CommitsOptions) has Head and Base fields, documented as:

https://github.com/sourcegraph/go-vcs/blob/d5c79b0b071fb52ee773641c60cfdce93c5f80d0/vcs/repository.go#L128-L129

The Base field is documented to produce results equivalent to `git log Base..Head`. However, that was not the case, the previous code produced results equivalent to `git log Head...Base` instead.

In many cases, those two are equivalent, which is likely why it has gone unnoticed (and the previous tests didn't catch this).

Add more thorough test coverage to catch the subtle difference.