### PR TITLE
Skip remaining few hg tests.

### DIFF
--- a/vcs/repository_test.go
+++ b/vcs/repository_test.go
@@ -1722,6 +1722,10 @@ func TestClone(t *testing.T) {
 	}
 
 	for _, test := range tests {
+		if test.vcs == "hg" {
+			continue // hg broken, see issue #104.
+		}
+
 		_, err := vcs.Clone(test.vcs, test.url, test.dir, vcs.CloneOpt{})
 		if err != nil {
 			t.Errorf("Clone(%q, %q, %q): %s", test.vcs, test.url, test.dir, err)
@@ -1766,6 +1770,10 @@ func TestRepository_UpdateEverything(t *testing.T) {
 	}
 
 	for _, test := range tests {
+		if test.vcs == "hg" {
+			continue // hg broken, see issue #104.
+		}
+
 		_, err := vcs.Clone(test.vcs, test.baseDir, test.headDir, vcs.CloneOpt{Bare: true, Mirror: true})
 		if err != nil {
 			t.Errorf("Clone(%q, %q, %q): %s", test.vcs, test.baseDir, test.headDir, err)
@@ -1893,6 +1901,7 @@ func makeGitRepositoryGoGit(t testing.TB, cmds ...string) *git.Repository {
 // temporary directory (returned as dir).
 func initHgRepository(t testing.TB, cmds ...string) (dir string) {
 	dir = makeTmpDir(t, "hg")
+	return dir // hg broken, see issue #104.
 	cmds = append([]string{"hg init"}, cmds...)
 	for _, cmd := range cmds {
 		c := exec.Command("bash", "-c", cmd)


### PR DESCRIPTION
Due to issue #104, most of hg tests were skipped in PR #103. This change skips the remaining few hg tests. As a result, `./vcs` package tests can pass without hg binary installed.

When issue #104 is resolved, all of the hg tests can be reinstated.

Updates PR #103.
Updates issue #104.