### PR TITLE
Fix inconsistency in annotated tag dereferencing; add test coverage for it.

### DIFF
--- a/vcs/git/repo.go
+++ b/vcs/git/repo.go
@@ -102,6 +102,10 @@ func (r *Repository) ResolveRevision(spec string) (vcs.CommitID, error) {
 // ResolveTag returns the tag with the given name, or
 // ErrTagNotFound if no such tag exists.
 func (r *Repository) ResolveTag(name string) (vcs.CommitID, error) {
+	// TODO: Implement non-fallback that dereferences annotated tags
+	//       consistently with gitcmd version. See issue #24.
+	return r.Repository.ResolveTag(name)
+
 	id, err := r.repo.GetCommitIdOfTag(name)
 	if _, ok := err.(git.RefNotFound); ok {
 		return "", vcs.ErrTagNotFound

--- a/vcs/repository_test.go
+++ b/vcs/repository_test.go
@@ -193,7 +193,7 @@ func TestRepository_ResolveRevision(t *testing.T) {
 		"git go-git annotated tag": {
 			repo:         makeGitRepositoryGoGit(t, gitCommands...),
 			spec:         "ta",
-			wantCommitID: "d07bdca22f4731f877b3b98177adc033c7a22263",
+			wantCommitID: "ea167fe3d76b1e5fd3ed8ca44cbd2fe3897684f8",
 		},
 		"hg native": {
 			repo:         makeHgRepositoryNative(t, hgCommands...),
@@ -343,7 +343,7 @@ func TestRepository_ResolveTag(t *testing.T) {
 		"git go-git annotated tag": {
 			repo:         makeGitRepositoryGoGit(t, gitCommands...),
 			tag:          "ta",
-			wantCommitID: "d07bdca22f4731f877b3b98177adc033c7a22263",
+			wantCommitID: "ea167fe3d76b1e5fd3ed8ca44cbd2fe3897684f8",
 		},
 		"hg native": {
 			repo:         makeHgRepositoryNative(t, hgCommands...),
@@ -741,7 +741,7 @@ func TestRepository_Tags(t *testing.T) {
 			wantTags: []*vcs.Tag{
 				{Name: "t0", CommitID: "ea167fe3d76b1e5fd3ed8ca44cbd2fe3897684f8"},
 				{Name: "t1", CommitID: "ea167fe3d76b1e5fd3ed8ca44cbd2fe3897684f8"},
-				{Name: "ta", CommitID: "d07bdca22f4731f877b3b98177adc033c7a22263"},
+				{Name: "ta", CommitID: "ea167fe3d76b1e5fd3ed8ca44cbd2fe3897684f8"},
 			},
 		},
 		"git go-git": {
@@ -749,7 +749,7 @@ func TestRepository_Tags(t *testing.T) {
 			wantTags: []*vcs.Tag{
 				{Name: "t0", CommitID: "ea167fe3d76b1e5fd3ed8ca44cbd2fe3897684f8"},
 				{Name: "t1", CommitID: "ea167fe3d76b1e5fd3ed8ca44cbd2fe3897684f8"},
-				{Name: "ta", CommitID: "d07bdca22f4731f877b3b98177adc033c7a22263"},
+				{Name: "ta", CommitID: "ea167fe3d76b1e5fd3ed8ca44cbd2fe3897684f8"},
 			},
 		},
 		"hg native": {
@@ -1615,7 +1615,7 @@ func TestRepository_FileSystem_fromTag(t *testing.T) {
 		"git cmd annotated tag": {
 			repo:         makeGitRepositoryCmd(t, gitCommands...),
 			spec:         "ta",
-			wantCommitID: "", // TODO.
+			wantCommitID: "00143c1744a30ce602c4585b9c351c3c108841e3",
 		},
 		"git go-git lightweight tag": {
 			repo:         makeGitRepositoryGoGit(t, gitCommands...),
@@ -1625,16 +1625,11 @@ func TestRepository_FileSystem_fromTag(t *testing.T) {
 		"git go-git annotated tag": {
 			repo:         makeGitRepositoryGoGit(t, gitCommands...),
 			spec:         "ta",
-			wantCommitID: "", // TODO.
+			wantCommitID: "00143c1744a30ce602c4585b9c351c3c108841e3",
 		},
 	}
 
 	for label, test := range tests {
-		if strings.Contains(label, "annotated") {
-			// TODO: Resolve issue 24, make the annotated test cases pass, and remove this skip.
-			t.Skip("skipping annotated tag test case, because it would fail; see issue https://github.com/sourcegraph/go-vcs/issues/24")
-		}
-
 		commitID, err := test.repo.ResolveRevision(test.spec)
 		if err != nil {
 			t.Errorf("%s: ResolveRevision: %s", label, err)


### PR DESCRIPTION
There was inconsistency in how annotated tags were handled by various git backends (git, gitcmd) and various methods (`ResolveRevision`, `ResolveTag`, `Tags`). In some cases, annotated tags were dereferenced, and in other cases, they were not. This is issue #24.

This PR fixes the inconsistency by opting to always dereference annotated tags to the underlying commit ID.

It consists of two _logical_ commits (please don't squash them, otherwise information will be lost):

1. First commit adds tests that cover the inconsistent annotated tag behavior, without changing the implementation. The tests demonstrate the inconsistent behavior, and are passing.

2. Second commit changes `git` and `gitcmd` behavior to always dereference annotated tags, and updates tests to have consistent output. The tests are passing.

The decision to always dereference annotated tags is based the following rationale. This behavior is more consistent with the high level nature of the `vcs` API, and it's easier for users to consume. If detailed tag information is needed, support for that can be added as an optional enhancement.

Fixes #24.

/cc @keegancsmith @slimsag Happy to answer any questions about this, or elaborate on any part.