### PR TITLE
Travis: Run tests on Windows.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 sudo: false
+os:
+  - linux
+  - windows
 language: go
 go:
   - "1.x"


### PR DESCRIPTION
There has been work done to the library over time to support Windows.
There's a chance for Windows support to deteriorate over time, since
it's not tested often. Fix that by running tests on Windows in CI.
Travis CI has recently added support for Windows, making this possible.

References:

- https://blog.travis-ci.com/2018-10-11-windows-early-release
- https://twitter.com/travisci/status/1050777251862720513