### PR TITLE
cmd/go-vcs, vcs/hgcmd: update .../sourcegraph/go-diff/diff import path

### DIFF
--- a/cmd/go-vcs/go-vcs.go
+++ b/cmd/go-vcs/go-vcs.go
@@ -15,7 +15,7 @@ import (
 	"time"
 
 	"github.com/kr/text"
-	"sourcegraph.com/sourcegraph/go-diff/diff"
+	"github.com/sourcegraph/go-diff/diff"
 	"sourcegraph.com/sourcegraph/go-vcs/vcs"
 	_ "sourcegraph.com/sourcegraph/go-vcs/vcs/git"
 	_ "sourcegraph.com/sourcegraph/go-vcs/vcs/gitcmd"

--- a/vcs/hgcmd/repo.go
+++ b/vcs/hgcmd/repo.go
@@ -16,7 +16,7 @@ import (
 	"strings"
 	"time"
 
-	"sourcegraph.com/sourcegraph/go-diff/diff"
+	"github.com/sourcegraph/go-diff/diff"
 	"sourcegraph.com/sourcegraph/go-vcs/vcs"
 	"sourcegraph.com/sourcegraph/go-vcs/vcs/internal"
 	"sourcegraph.com/sourcegraph/go-vcs/vcs/util"


### PR DESCRIPTION
It has changed in https://github.com/sourcegraph/go-diff/pull/30.

Updates https://github.com/sourcegraph/go-diff/issues/27

/cc @sqs

~~You should probably not merge this before https://github.com/sourcegraph/go-diff/issues/33 is resolved, otherwise this PR will break this project in module mode.~~ **Edit:** Issue https://github.com/sourcegraph/go-diff/issues/33 has been resolved, so this is safe to merge now.