### PR TITLE
Remove use of ioutil package

### DIFF
--- a/cmd/go-vcs/go-vcs.go
+++ b/cmd/go-vcs/go-vcs.go
@@ -5,7 +5,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/url"
 	"os"
@@ -70,7 +69,7 @@ func main() {
 
 		opt := vcs.CloneOpt{}
 		if *sshKeyFile != "" {
-			key, err := ioutil.ReadFile(*sshKeyFile)
+			key, err := os.ReadFile(*sshKeyFile)
 			if err != nil {
 				log.Fatal(err)
 			}
@@ -217,7 +216,7 @@ func main() {
 			log.Fatal(err)
 		}
 
-		b, err := ioutil.ReadAll(f)
+		b, err := io.ReadAll(f)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/vcs/bench_test.go
+++ b/vcs/bench_test.go
@@ -2,7 +2,6 @@ package vcs_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"path/filepath"
 	"testing"
 
@@ -360,7 +359,7 @@ func benchFileSystem(b *testing.B, r benchRepository, tag string, files []string
 			b.Errorf("fs.Open(%q): %s", f, err)
 			return
 		}
-		_, err = ioutil.ReadAll(file)
+		_, err = io.ReadAll(file)
 		if err != nil {
 			b.Errorf("ReadAll(%q): %s", f, err)
 			return

--- a/vcs/gitcmd/repo.go
+++ b/vcs/gitcmd/repo.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -1292,7 +1291,7 @@ func makeGitSSHWrapper(privKey []byte) (sshWrapper, sshWrapperDir, keyFile strin
 		otherOpt = "-o StrictHostKeyChecking=no"
 	}
 
-	kf, err := ioutil.TempFile("", "go-vcs-gitcmd-key")
+	kf, err := os.CreateTemp("", "go-vcs-gitcmd-key")
 	if err != nil {
 		return "", "", "", err
 	}

--- a/vcs/hgcmd/repo.go
+++ b/vcs/hgcmd/repo.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -402,7 +401,7 @@ func (r *Repository) BlameFile(path string, opt *vcs.BlameOptions) ([]*vcs.Hunk,
 		}
 	}
 	jsonErr := json.NewDecoder(in).Decode(&data)
-	errOut, _ := ioutil.ReadAll(stderr)
+	errOut, _ := io.ReadAll(stderr)
 	if jsonErr != nil {
 		cmd.Wait()
 		return nil, fmt.Errorf("%s (stderr: %s)", jsonErr, errOut)
@@ -504,7 +503,7 @@ func (fs *hgFSCmd) Stat(path string) (os.FileInfo, error) {
 		return nil, err
 	}
 	defer f.Close()
-	data, err := ioutil.ReadAll(f)
+	data, err := io.ReadAll(f)
 
 	return &util.FileInfo{Name_: filepath.Base(path), Size_: int64(len(data)),
 		ModTime_: mtime}, nil

--- a/vcs/internal/script.go
+++ b/vcs/internal/script.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -20,7 +19,7 @@ func ScriptFile(prefix string) (filePath string, rootPath string, err error) {
 		suffix = ".bat"
 	}
 
-	tempDir, err := ioutil.TempDir("", prefix)
+	tempDir, err := os.MkdirTemp("", prefix)
 	if err != nil {
 		return "", "", err
 	}
@@ -29,7 +28,7 @@ func ScriptFile(prefix string) (filePath string, rootPath string, err error) {
 
 // Wrapper around ioutil.WriteFile that updates permissions regardless if file existed before
 func WriteFileWithPermissions(file string, content []byte, perm os.FileMode) error {
-	err := ioutil.WriteFile(file, content, perm)
+	err := os.WriteFile(file, content, perm)
 	if err != nil {
 		return err
 	}

--- a/vcs/repository_test.go
+++ b/vcs/repository_test.go
@@ -2,7 +2,6 @@ package vcs_test
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -1491,7 +1490,7 @@ func TestRepository_FileSystem(t *testing.T) {
 			t.Errorf("%s: fs1.Open(dir1/file1): %s", label, err)
 			continue
 		}
-		file1Data, err := ioutil.ReadAll(file1)
+		file1Data, err := io.ReadAll(file1)
 		if err != nil {
 			t.Errorf("%s: ReadAll(file1): %s", label, err)
 			continue
@@ -1661,7 +1660,7 @@ func TestRepository_FileSystem_fromTag(t *testing.T) {
 			t.Errorf("%s: fs.Open(file1): %s", label, err)
 			continue
 		}
-		file1Data, err := ioutil.ReadAll(file1)
+		file1Data, err := io.ReadAll(file1)
 		if err != nil {
 			t.Errorf("%s: ReadAll(file1): %s", label, err)
 			continue
@@ -1832,7 +1831,7 @@ func TestRepository_FileSystem_gitSubmodules(t *testing.T) {
 			t.Errorf("%s: fs.Open(submod): %s", label, err)
 			continue
 		}
-		if _, err := ioutil.ReadAll(sr); err != nil {
+		if _, err := io.ReadAll(sr); err != nil {
 			t.Errorf("%s: ReadAll(submod file): %s", label, err)
 			continue
 		}

--- a/vcs/search_test.go
+++ b/vcs/search_test.go
@@ -2,7 +2,6 @@ package vcs_test
 
 import (
 	"bufio"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -130,7 +129,7 @@ func createLongFile() (file string, line []byte, err error) {
 		}
 	}
 
-	tmp, err := ioutil.TempFile("", "test")
+	tmp, err := os.CreateTemp("", "test")
 	if err != nil {
 		return "", longline, err
 	}

--- a/vcs/util/keyfile.go
+++ b/vcs/util/keyfile.go
@@ -3,7 +3,6 @@ package util
 import (
 	"crypto/sha256"
 	"encoding/base64"
-	"io/ioutil"
 	"os"
 )
 
@@ -17,7 +16,7 @@ func WriteKeyTempFile(namePrefix string, keyData []byte) (filename string, tmp *
 	hasher.Write([]byte(namePrefix))
 	hash := base64.URLEncoding.EncodeToString(hasher.Sum(nil))
 
-	tmpfile, err := ioutil.TempFile("", "go-vcs-"+hash+"-")
+	tmpfile, err := os.CreateTemp("", "go-vcs-"+hash+"-")
 	if err != nil {
 		return "", nil, err
 	}

--- a/vcs/util_for_test.go
+++ b/vcs/util_for_test.go
@@ -3,7 +3,6 @@ package vcs_test
 import (
 	"encoding/json"
 	"flag"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -29,7 +28,7 @@ func init() {
 
 // makeTmpDir creates a temporary directory underneath baseTempDir.
 func makeTmpDir(t testing.TB, suffix string) string {
-	dir, err := ioutil.TempDir(baseTempDir, suffix)
+	dir, err := os.MkdirTemp(baseTempDir, suffix)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/vcs/vcs.pb.go
+++ b/vcs/vcs.pb.go
@@ -21,14 +21,19 @@
 */
 package vcs
 
-import proto "github.com/gogo/protobuf/proto"
-import fmt "fmt"
-import math "math"
+import (
+	fmt "fmt"
 
-// discarding unused import gogoproto "github.com/gogo/protobuf/gogoproto"
-import pbtypes "sourcegraph.com/sqs/pbtypes"
+	proto "github.com/gogo/protobuf/proto"
 
-import io "io"
+	math "math"
+
+	// discarding unused import gogoproto "github.com/gogo/protobuf/gogoproto"
+
+	pbtypes "sourcegraph.com/sqs/pbtypes"
+
+	io "io"
+)
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal


### PR DESCRIPTION
Removes usage of the deprecated ioutil package as described [here](https://golang.org/doc/go1.16#ioutil)

[_Created by Sourcegraph batch change `rslade/deprecate-ioutil`._](https://k8s.sgdev.org/users/rslade/batch-changes/deprecate-ioutil)