### PR TITLE
vcs: add DiffOptions.ContextLines field

### DIFF
--- a/vcs/diff_test.go
+++ b/vcs/diff_test.go
@@ -17,10 +17,11 @@ func TestRepository_Diff(t *testing.T) {
 
 	gitCommands := []string{
 		"echo line1 > f",
+		"echo line2 >> f",
 		"git add f",
 		"GIT_COMMITTER_NAME=a GIT_COMMITTER_EMAIL=a@a.com GIT_COMMITTER_DATE=2006-01-02T15:04:05Z git commit -m foo --author='a <a@a.com>' --date 2006-01-02T15:04:05Z",
 		"git tag testbase",
-		"echo line2 >> f",
+		"echo line3 >> f",
 		"git add f",
 		"GIT_COMMITTER_NAME=a GIT_COMMITTER_EMAIL=a@a.com GIT_COMMITTER_DATE=2006-01-02T15:04:05Z git commit -m foo --author='a <a@a.com>' --date 2006-01-02T15:04:05Z",
 		"git tag testhead",
@@ -54,14 +55,14 @@ func TestRepository_Diff(t *testing.T) {
 			repo: makeGitRepositoryCmd(t, gitCommands...),
 			base: "testbase", head: "testhead",
 			wantDiff: &vcs.Diff{
-				Raw: "diff --git f f\nindex a29bdeb434d874c9b1d8969c40c42161b03fafdc..c0d0fb45c382919737f8d0c20aaf57cf89b74af8 100644\n--- f\n+++ f\n@@ -1 +1,2 @@\n line1\n+line2\n",
+				Raw: "diff --git f f\nindex c0d0fb45c382919737f8d0c20aaf57cf89b74af8..83db48f84ec878fbfb30b46d16630e944e34f205 100644\n--- f\n+++ f\n@@ -1,2 +1,3 @@\n line1\n line2\n+line3\n",
 			},
 		},
 		"git go-git": {
 			repo: makeGitRepositoryGoGit(t, gitCommands...),
 			base: "testbase", head: "testhead",
 			wantDiff: &vcs.Diff{
-				Raw: "diff --git f f\nindex a29bdeb434d874c9b1d8969c40c42161b03fafdc..c0d0fb45c382919737f8d0c20aaf57cf89b74af8 100644\n--- f\n+++ f\n@@ -1 +1,2 @@\n line1\n+line2\n",
+				Raw: "diff --git f f\nindex c0d0fb45c382919737f8d0c20aaf57cf89b74af8..83db48f84ec878fbfb30b46d16630e944e34f205 100644\n--- f\n+++ f\n@@ -1,2 +1,3 @@\n line1\n line2\n+line3\n",
 			},
 		},
 		"hg cmd": {
@@ -69,6 +70,17 @@ func TestRepository_Diff(t *testing.T) {
 			base: "testbase", head: "testhead",
 			wantDiff: &vcs.Diff{
 				Raw: "diff --git .hgtags .hgtags\nnew file mode 100644\n--- /dev/null\n+++ .hgtags\n@@ -0,0 +1,1 @@\n+%(baseCommitID) testbase\ndiff --git f f\n--- f\n+++ f\n@@ -1,1 +1,2 @@\n line1\n+line2\n",
+			},
+		},
+
+		"git cmd ContextLines=1": {
+			repo: makeGitRepositoryCmd(t, gitCommands...),
+			base: "testbase", head: "testhead",
+			opt: &vcs.DiffOptions{
+				ContextLines: 1,
+			},
+			wantDiff: &vcs.Diff{
+				Raw: "diff --git f f\nindex c0d0fb45c382919737f8d0c20aaf57cf89b74af8..83db48f84ec878fbfb30b46d16630e944e34f205 100644\n--- f\n+++ f\n@@ -2 +2,2 @@ line1\n line2\n+line3\n",
 			},
 		},
 	}

--- a/vcs/gitcmd/repo.go
+++ b/vcs/gitcmd/repo.go
@@ -559,6 +559,9 @@ func (r *Repository) Diff(base, head vcs.CommitID, opt *vcs.DiffOptions) (*vcs.D
 		opt = &vcs.DiffOptions{}
 	}
 	args := []string{"diff", "--full-index"}
+	if opt.ContextLines != 0 {
+		args = append(args, fmt.Sprintf("-U%d", opt.ContextLines))
+	}
 	if opt.DetectRenames {
 		args = append(args, "-M")
 	}

--- a/vcs/repository.go
+++ b/vcs/repository.go
@@ -147,6 +147,7 @@ type CommittersOptions struct {
 // DiffOptions configures a diff.
 type DiffOptions struct {
 	Paths                 []string // constrain diff to these pathspecs
+	ContextLines          int      // generate diff with this many lines of context (0 means default)
 	DetectRenames         bool
 	OrigPrefix, NewPrefix string // prefixes for orig and new filenames (e.g., "a/", "b/")
 


### PR DESCRIPTION
It's proven to be useful to have control over how many context lines are included in a diff.

(I'm cleaning up some old fork repos, and figured I'd try to upstream this change I've been using locally for a while. Feel free to close if it doesn't seem useful. Thanks.)